### PR TITLE
Fix sign-in popup logic and dropdown trigger

### DIFF
--- a/src/signin.tsx
+++ b/src/signin.tsx
@@ -6,7 +6,6 @@ export function SignInPage() {
   const { user, signIn, isLoadingUser } = useAuth()
   const [isPopup, setIsPopup] = useState(false)
   const signInCalled = useRef(false)
-  console.log(isLoadingUser)
 
   useEffect(() => {
     // Method 1: Check if window has an opener (opened by another window)
@@ -19,6 +18,16 @@ export function SignInPage() {
 
   useEffect(() => {
     if (isLoadingUser) return
+
+    if (user) {
+      if (isPopup && window.opener && window.opener !== window) {
+        window.opener.postMessage({ type: 'SIGNIN_COMPLETE' }, window.location.origin)
+        setTimeout(() => window.close(), 100)
+      } else {
+        window.location.href = '/'
+      }
+      return
+    }
 
     if (!signInCalled.current) {
       signInCalled.current = true

--- a/src/user-center.tsx
+++ b/src/user-center.tsx
@@ -67,7 +67,7 @@ export const UserCenter: React.FC<UserCenterProps> = ({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="destructive-none">
+      <DropdownMenuTrigger className="outline-none">
         <Avatar className={`h-9 w-9 transition-all hover:ring-2 hover:ring-slate-200 ${className}`}>
           <AvatarFallback className="bg-slate-50">
             <UserCircle className="h-5 w-5 text-slate-400" />


### PR DESCRIPTION
## Summary
- ensure `SignInPage` doesn't start another login when user is already authenticated
- close popup automatically and redirect correctly
- fix incorrect dropdown trigger class name

## Testing
- `npm run build:tsc`

------
https://chatgpt.com/codex/tasks/task_e_68402bf658188320b59bdb45d0889444