### PR TITLE
Fix: Gate user state update on valid JWT to prevent stale login UI

### DIFF
--- a/src/context.tsx
+++ b/src/context.tsx
@@ -97,14 +97,21 @@ const InternalAuthProvider = ({
           const claims = await getIdTokenClaims()
           const jwt = await getAccessToken(defaultResource)
 
-          // Save JWT token to cookie
           if (jwt) {
+            // Only set user as logged in if we actually have a valid access token
             jwtCookieUtils.saveToken(jwt)
+            setUser(transformUser(claims))
+            // Reset error count on success
+            errorCount.current = 0
+          } else {
+            // Refresh token expired (e.g. user was gone > 30 days) — session is dead.
+            // The Logto SDK still reports isAuthenticated=true because it reads stale
+            // localStorage, but we have no usable token, so we must log out cleanly.
+            console.warn('Access token unavailable — session likely expired. Forcing logout.')
+            setUser(null)
+            jwtCookieUtils.removeToken()
+            await logtoSignOut()
           }
-
-          setUser(transformUser(claims))
-          // Reset error count on success
-          errorCount.current = 0
         } catch (error: unknown) {
           console.error('Error fetching user claims:', error)
           errorCount.current += 1


### PR DESCRIPTION
When a refresh token expires (e.g., user absent > 30 days), getAccessToken()
silently returns null without throwing. The previous code called setUser()
unconditionally, creating a split-brain state: UI shows cached user data
but no valid JWT exists, causing API calls to fail with 401 errors.

This fix gates setUser() on successful JWT retrieval:
- If jwt exists: save token and set user state (success path)
- If jwt is null: log warning, clear user state, remove token, and force logout
  (expired session path)

This ensures the UI correctly reflects the actual authentication state and
triggers proper logout flow when the session expires, closing the gap between
cached claims and missing tokens.

Existing error handling path remains unchanged - if getAccessToken() throws
an exception (network error, etc.), the catch block still handles it correctly.

https://claude.ai/code/session_015RtKF2J2piDZETdTzMBEnS