### PR TITLE
feat: add proactive token refresh scheduling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,10 +41,14 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "express": "^5.2.1",
         "happy-dom": "^20.7.0",
+        "rimraf": "^5.0.10",
         "supertest": "^7.2.2",
         "typescript": "^5.0.4",
         "vite": "^4.0.0",
         "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.0.0 || ^22.0.0 || ^24.0.0"
       },
       "peerDependencies": {
         "@logto/react": "^3.0.0 || ^4.0.0",
@@ -1009,6 +1013,50 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1170,6 +1218,16 @@
       "dev": true,
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@polka/url": {
@@ -3949,10 +4007,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
     "node_modules/encodeurl": {
@@ -5045,6 +5115,65 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flat-cache/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/flat-cache/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/flat-cache/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -5064,6 +5193,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/form-data": {
@@ -5267,21 +5412,21 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": "*"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5299,26 +5444,19 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -5840,6 +5978,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -6141,6 +6288,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jiti": {
@@ -6772,6 +6934,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "dev": true,
@@ -7039,6 +7210,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7104,6 +7281,28 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
     "node_modules/path-to-regexp": {
@@ -7508,16 +7707,15 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
       "dev": true,
       "dependencies": {
-        "glob": "^7.1.3"
+        "glob": "^10.3.7"
       },
       "bin": {
-        "rimraf": "bin.js"
+        "rimraf": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -7893,6 +8091,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "dev": true,
@@ -7954,6 +8164,71 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -8050,6 +8325,19 @@
       }
     },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -8980,6 +9268,115 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:coverage": "vitest --coverage",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "clean": "rm -rf dist",
+    "clean": "rimraf dist",
     "prepublishOnly": "npm run clean && npm run build",
     "publish": "npm publish --access public --provenance"
   },
@@ -87,6 +87,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "express": "^5.2.1",
     "happy-dom": "^20.7.0",
+    "rimraf": "^5.0.10",
     "supertest": "^7.2.2",
     "typescript": "^5.0.4",
     "vite": "^4.0.0",

--- a/src/context.test.tsx
+++ b/src/context.test.tsx
@@ -52,6 +52,11 @@ const createMockLogtoContext = (overrides: Partial<ReturnType<typeof useLogto>> 
   ...overrides,
 })
 
+const createMockJwt = (exp: number) => {
+  const encode = (value: object) => Buffer.from(JSON.stringify(value)).toString('base64url')
+  return `${encode({ alg: 'none', typ: 'JWT' })}.${encode({ exp })}.signature`
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(useLogto).mockReturnValue(createMockLogtoContext())
@@ -344,24 +349,27 @@ describe('Proactive Token Refresh', () => {
     )
   }
 
-  it('refreshes the session shortly before token expiry and reschedules from the new exp', async () => {
-    const initialExp = Math.floor(Date.now() / 1000) + 61
-    const refreshedExp = Math.floor(Date.now() / 1000) + 300
+  it('refreshes based on the access token expiry, not the id token expiry', async () => {
+    const initialAccessTokenExp = Math.floor(Date.now() / 1000) + 61
+    const refreshedAccessTokenExp = Math.floor(Date.now() / 1000) + 300
     const getIdTokenClaims = vi
       .fn()
       .mockResolvedValueOnce({
         sub: 'user-123',
         name: 'Test User',
         email: 'test@example.com',
-        exp: initialExp,
+        exp: Math.floor(Date.now() / 1000) + 3600,
       })
       .mockResolvedValueOnce({
         sub: 'user-123',
         name: 'Test User',
         email: 'test@example.com',
-        exp: refreshedExp,
+        exp: Math.floor(Date.now() / 1000) + 3600,
       })
-    const getAccessToken = vi.fn().mockResolvedValueOnce('token-1').mockResolvedValueOnce('token-2')
+    const getAccessToken = vi
+      .fn()
+      .mockResolvedValueOnce(createMockJwt(initialAccessTokenExp))
+      .mockResolvedValueOnce(createMockJwt(refreshedAccessTokenExp))
     const signOut = vi.fn()
 
     vi.mocked(useLogto).mockReturnValue(
@@ -381,10 +389,10 @@ describe('Proactive Token Refresh', () => {
 
     await waitFor(() => expect(screen.getByText('user: user-123')).toBeInTheDocument())
     expect(getAccessToken).toHaveBeenCalledTimes(1)
-    expect(jwtCookieUtils.saveToken).toHaveBeenLastCalledWith('token-1')
+    expect(jwtCookieUtils.saveToken).toHaveBeenLastCalledWith(createMockJwt(initialAccessTokenExp))
 
     await waitFor(() => expect(getAccessToken).toHaveBeenCalledTimes(2), { timeout: 3000 })
-    expect(jwtCookieUtils.saveToken).toHaveBeenLastCalledWith('token-2')
+    expect(jwtCookieUtils.saveToken).toHaveBeenLastCalledWith(createMockJwt(refreshedAccessTokenExp))
     expect(signOut).not.toHaveBeenCalled()
   }, 10000)
 
@@ -399,7 +407,7 @@ describe('Proactive Token Refresh', () => {
         exp: initialExp,
       })
       .mockRejectedValueOnce(new Error('invalid_grant'))
-    const getAccessToken = vi.fn().mockResolvedValueOnce('token-1')
+    const getAccessToken = vi.fn().mockResolvedValueOnce(createMockJwt(initialExp))
     const signOut = vi.fn()
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -445,7 +453,7 @@ describe('Proactive Token Refresh', () => {
         email: 'test@example.com',
         exp: initialExp,
       })
-    const getAccessToken = vi.fn().mockResolvedValueOnce('token-1').mockResolvedValueOnce(null)
+    const getAccessToken = vi.fn().mockResolvedValueOnce(createMockJwt(initialExp)).mockResolvedValueOnce(null)
     const signOut = vi.fn()
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
@@ -471,6 +479,41 @@ describe('Proactive Token Refresh', () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('session likely expired'))
 
     warnSpy.mockRestore()
+  }, 10000)
+
+  it('does not enter a 1-second refresh loop when the refreshed token keeps the same exp', async () => {
+    const stableExp = Math.floor(Date.now() / 1000) + 61
+    const stableToken = createMockJwt(stableExp)
+    const getIdTokenClaims = vi.fn().mockResolvedValue({
+      sub: 'user-123',
+      name: 'Test User',
+      email: 'test@example.com',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    })
+    const getAccessToken = vi.fn().mockResolvedValue(stableToken)
+
+    vi.mocked(useLogto).mockReturnValue(
+      createMockLogtoContext({
+        isAuthenticated: true,
+        getIdTokenClaims,
+        getAccessToken,
+      }),
+    )
+
+    render(
+      <AuthProvider config={mockConfig}>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByText('user: user-123')).toBeInTheDocument())
+    await waitFor(() => expect(getAccessToken).toHaveBeenCalledTimes(2), { timeout: 3000 })
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 2000))
+    })
+
+    expect(getAccessToken).toHaveBeenCalledTimes(2)
   }, 10000)
 })
 

--- a/src/context.test.tsx
+++ b/src/context.test.tsx
@@ -5,23 +5,13 @@ import { AuthProvider } from './context'
 import { useAuthContext } from './context'
 import { useAuth } from './useAuth'
 import { useNavigation } from './navigation'
-import type { LogtoConfig } from '@logto/react'
+import { useLogto, type LogtoConfig } from '@logto/react'
+import { jwtCookieUtils } from './utils'
 
 // Mock @logto/react
 vi.mock('@logto/react', () => ({
   LogtoProvider: ({ children }: { children: ReactNode }) => children,
-  useLogto: () => ({
-    isAuthenticated: false,
-    isLoading: false,
-    getIdTokenClaims: vi.fn().mockResolvedValue({
-      sub: 'user-123',
-      name: 'Test User',
-      email: 'test@example.com',
-    }),
-    getAccessToken: vi.fn().mockResolvedValue('mock-token'),
-    signIn: vi.fn(),
-    signOut: vi.fn(),
-  }),
+  useLogto: vi.fn(),
 }))
 
 // Mock utils
@@ -48,15 +38,30 @@ const mockConfig: LogtoConfig = {
   appId: 'test-app-id',
 }
 
+const createMockLogtoContext = (overrides: Partial<ReturnType<typeof useLogto>> = {}) => ({
+  isAuthenticated: false,
+  isLoading: false,
+  getIdTokenClaims: vi.fn().mockResolvedValue({
+    sub: 'user-123',
+    name: 'Test User',
+    email: 'test@example.com',
+  }),
+  getAccessToken: vi.fn().mockResolvedValue('mock-token'),
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  ...overrides,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(useLogto).mockReturnValue(createMockLogtoContext())
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
 describe('AuthProvider Context', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  afterEach(() => {
-    vi.clearAllMocks()
-  })
-
   it('should render children', () => {
     render(
       <AuthProvider config={mockConfig}>
@@ -327,6 +332,148 @@ describe('Development Config Warnings', () => {
   })
 })
 
+describe('Proactive Token Refresh', () => {
+  const AuthStateProbe = () => {
+    const { user, isLoadingUser } = useAuthContext()
+
+    return (
+      <div>
+        <div>loading: {isLoadingUser ? 'true' : 'false'}</div>
+        <div>user: {user ? user.id : 'none'}</div>
+      </div>
+    )
+  }
+
+  it('refreshes the session shortly before token expiry and reschedules from the new exp', async () => {
+    const initialExp = Math.floor(Date.now() / 1000) + 61
+    const refreshedExp = Math.floor(Date.now() / 1000) + 300
+    const getIdTokenClaims = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sub: 'user-123',
+        name: 'Test User',
+        email: 'test@example.com',
+        exp: initialExp,
+      })
+      .mockResolvedValueOnce({
+        sub: 'user-123',
+        name: 'Test User',
+        email: 'test@example.com',
+        exp: refreshedExp,
+      })
+    const getAccessToken = vi.fn().mockResolvedValueOnce('token-1').mockResolvedValueOnce('token-2')
+    const signOut = vi.fn()
+
+    vi.mocked(useLogto).mockReturnValue(
+      createMockLogtoContext({
+        isAuthenticated: true,
+        getIdTokenClaims,
+        getAccessToken,
+        signOut,
+      }),
+    )
+
+    render(
+      <AuthProvider config={mockConfig}>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByText('user: user-123')).toBeInTheDocument())
+    expect(getAccessToken).toHaveBeenCalledTimes(1)
+    expect(jwtCookieUtils.saveToken).toHaveBeenLastCalledWith('token-1')
+
+    await waitFor(() => expect(getAccessToken).toHaveBeenCalledTimes(2), { timeout: 3000 })
+    expect(jwtCookieUtils.saveToken).toHaveBeenLastCalledWith('token-2')
+    expect(signOut).not.toHaveBeenCalled()
+  }, 10000)
+
+  it('signs the user out when a scheduled refresh fails with an auth error', async () => {
+    const initialExp = Math.floor(Date.now() / 1000) + 61
+    const getIdTokenClaims = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sub: 'user-123',
+        name: 'Test User',
+        email: 'test@example.com',
+        exp: initialExp,
+      })
+      .mockRejectedValueOnce(new Error('invalid_grant'))
+    const getAccessToken = vi.fn().mockResolvedValueOnce('token-1')
+    const signOut = vi.fn()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    vi.mocked(useLogto).mockReturnValue(
+      createMockLogtoContext({
+        isAuthenticated: true,
+        getIdTokenClaims,
+        getAccessToken,
+        signOut,
+      }),
+    )
+
+    render(
+      <AuthProvider config={mockConfig}>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByText('user: user-123')).toBeInTheDocument())
+
+    await waitFor(() => expect(signOut).toHaveBeenCalledTimes(1), { timeout: 3000 })
+    expect(jwtCookieUtils.removeToken).toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('forcing logout:'), 'invalid_grant')
+
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+  }, 10000)
+
+  it('falls back to logout when refresh returns no access token, indicating an expired refresh token', async () => {
+    const initialExp = Math.floor(Date.now() / 1000) + 61
+    const getIdTokenClaims = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sub: 'user-123',
+        name: 'Test User',
+        email: 'test@example.com',
+        exp: initialExp,
+      })
+      .mockResolvedValueOnce({
+        sub: 'user-123',
+        name: 'Test User',
+        email: 'test@example.com',
+        exp: initialExp,
+      })
+    const getAccessToken = vi.fn().mockResolvedValueOnce('token-1').mockResolvedValueOnce(null)
+    const signOut = vi.fn()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    vi.mocked(useLogto).mockReturnValue(
+      createMockLogtoContext({
+        isAuthenticated: true,
+        getIdTokenClaims,
+        getAccessToken,
+        signOut,
+      }),
+    )
+
+    render(
+      <AuthProvider config={mockConfig}>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByText('user: user-123')).toBeInTheDocument())
+
+    await waitFor(() => expect(signOut).toHaveBeenCalledTimes(1), { timeout: 3000 })
+    expect(jwtCookieUtils.removeToken).toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('session likely expired'))
+
+    warnSpy.mockRestore()
+  }, 10000)
+})
+
 // ---------------------------------------------------------------------------
 // Popup Sign-in Flow (task 5.3)
 // ---------------------------------------------------------------------------
@@ -346,6 +493,7 @@ describe('Popup Sign-in Flow', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+    vi.mocked(useLogto).mockReturnValue(createMockLogtoContext())
     mockPopup = { closed: false, close: vi.fn() }
     // Replace window.open with a mock that returns our popup handle
     Object.defineProperty(window, 'open', {

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -8,6 +8,41 @@ import type { AuthContextType, AuthProviderProps, LogtoUser } from './types.js'
 const POPUP_AUTH_EVENT_DELAY = 500
 const TOKEN_REFRESH_BUFFER_MS = 60_000
 const MIN_TOKEN_REFRESH_DELAY_MS = 1_000
+const TOKEN_REFRESH_RETRY_MS = 15_000
+
+const decodeBase64Url = (value: string): string | null => {
+  try {
+    const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
+
+    if (typeof atob === 'function') {
+      return atob(padded)
+    }
+
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(padded, 'base64').toString('utf8')
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+const getJwtExpiration = (token: string): number | undefined => {
+  const payload = token.split('.')[1]
+  if (!payload) return undefined
+
+  const decodedPayload = decodeBase64Url(payload)
+  if (!decodedPayload) return undefined
+
+  try {
+    const parsed = JSON.parse(decodedPayload) as { exp?: unknown }
+    return typeof parsed.exp === 'number' ? parsed.exp : undefined
+  } catch {
+    return undefined
+  }
+}
 
 // Create auth context
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
@@ -104,6 +139,8 @@ const InternalAuthProvider = ({
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>()
   /** Prevents overlapping timer-driven refresh attempts. */
   const refreshInFlightRef = useRef<boolean>(false)
+  /** Tracks the last access-token expiry used for scheduling to avoid tight loops when exp does not advance. */
+  const lastScheduledTokenExpRef = useRef<number | undefined>()
   /** Set to true in the unmount cleanup; guards async callbacks against firing on dead component. */
   const isUnmountedRef = useRef<boolean>(false)
   /** Tracks the popup-closed polling interval so it can be cleared on provider unmount. */
@@ -124,6 +161,11 @@ const InternalAuthProvider = ({
     refreshTimerRef.current = undefined
   }, [])
 
+  const resetRefreshSchedule = useCallback(() => {
+    clearRefreshTimer()
+    lastScheduledTokenExpRef.current = undefined
+  }, [clearRefreshTimer])
+
   const scheduleTokenRefresh = useCallback(
     (exp?: number) => {
       clearRefreshTimer()
@@ -132,7 +174,21 @@ const InternalAuthProvider = ({
         return
       }
 
-      const refreshDelay = Math.max(exp * 1000 - Date.now() - TOKEN_REFRESH_BUFFER_MS, MIN_TOKEN_REFRESH_DELAY_MS)
+      const previousExp = lastScheduledTokenExpRef.current
+      const expiresAtMs = exp * 1000
+      const timeUntilExpiry = expiresAtMs - Date.now()
+      const isUnchangedOrOlderExp = previousExp !== undefined && exp <= previousExp
+      let refreshDelay = timeUntilExpiry - TOKEN_REFRESH_BUFFER_MS
+
+      if (isUnchangedOrOlderExp && refreshDelay <= MIN_TOKEN_REFRESH_DELAY_MS) {
+        // If the SDK gave us the same access-token expiry again, avoid re-entering the
+        // refresh path every second. Retry on a slower cadence while the token is still valid.
+        refreshDelay = Math.min(Math.max(timeUntilExpiry, MIN_TOKEN_REFRESH_DELAY_MS), TOKEN_REFRESH_RETRY_MS)
+      } else {
+        refreshDelay = Math.max(refreshDelay, MIN_TOKEN_REFRESH_DELAY_MS)
+      }
+
+      lastScheduledTokenExpRef.current = exp
 
       refreshTimerRef.current = setTimeout(() => {
         if (isUnmountedRef.current || refreshInFlightRef.current) {
@@ -168,11 +224,10 @@ const InternalAuthProvider = ({
         try {
           const claims = await getIdTokenClaims()
           const jwt = await getAccessToken(defaultResource)
-          const tokenExp =
-            typeof claims === 'object' && claims !== null && 'exp' in claims && typeof claims.exp === 'number' ? claims.exp : undefined
 
           if (jwt) {
             // Only set user as logged in if we actually have a valid access token
+            const tokenExp = getJwtExpiration(jwt)
             jwtCookieUtils.saveToken(jwt)
             setUser(transformUser(claims))
             // Reset all error counters and any pending backoff on a successful fetch
@@ -187,7 +242,7 @@ const InternalAuthProvider = ({
             console.warn('Access token unavailable — session likely expired. Forcing logout.')
             setUser(null)
             jwtCookieUtils.removeToken()
-            clearRefreshTimer()
+            resetRefreshSchedule()
             await logtoSignOut()
           }
         } catch (error: unknown) {
@@ -261,7 +316,7 @@ const InternalAuthProvider = ({
               setUser(null)
               jwtCookieUtils.removeToken()
               transientErrorCount.current = 0
-              clearRefreshTimer()
+              resetRefreshSchedule()
               try {
                 await logtoSignOut()
               } catch (logoutError) {
@@ -277,7 +332,7 @@ const InternalAuthProvider = ({
             clearTimeout(backoffTimerRef.current)
             setUser(null)
             jwtCookieUtils.removeToken()
-            clearRefreshTimer()
+            resetRefreshSchedule()
             errorCount.current += 1
             transientErrorCount.current = 0
 
@@ -305,12 +360,12 @@ const InternalAuthProvider = ({
         errorCount.current = 0
         transientErrorCount.current = 0
         clearTimeout(backoffTimerRef.current)
-        clearRefreshTimer()
+        resetRefreshSchedule()
       }
 
       setIsLoadingUser(false)
     },
-    [clearRefreshTimer, defaultResource, getAccessToken, getIdTokenClaims, isAuthenticated, isLoading, logtoSignOut, scheduleTokenRefresh],
+    [defaultResource, getAccessToken, getIdTokenClaims, isAuthenticated, isLoading, logtoSignOut, resetRefreshSchedule, scheduleTokenRefresh],
   )
 
   useEffect(() => {
@@ -324,13 +379,13 @@ const InternalAuthProvider = ({
       // on a dead component tree (guards against the timer/unmount race condition).
       isUnmountedRef.current = true
       clearTimeout(backoffTimerRef.current)
-      clearRefreshTimer()
+      resetRefreshSchedule()
       // Clean up popup polling interval and 5-minute auto-cleanup timer in case
       // the provider is unmounted while a popup sign-in is still in progress.
       clearInterval(popupIntervalRef.current)
       clearTimeout(popupCleanupTimerRef.current)
     }
-  }, [clearRefreshTimer])
+  }, [resetRefreshSchedule])
 
   // Store the latest loadUser function in a ref to avoid recreating event listeners
   const loadUserRef = useRef(loadUser)
@@ -524,7 +579,7 @@ const InternalAuthProvider = ({
 
       // Always remove the JWT token cookie on sign out
       jwtCookieUtils.removeToken()
-      clearRefreshTimer()
+      resetRefreshSchedule()
 
       if (global) {
         // Global sign out - logs out from entire Logto ecosystem
@@ -546,7 +601,7 @@ const InternalAuthProvider = ({
       // Dispatch custom event to notify other windows/tabs
       window.dispatchEvent(new CustomEvent('auth-state-changed'))
     },
-    [clearRefreshTimer, logtoSignOut],
+    [logtoSignOut, resetRefreshSchedule],
   )
 
   const value: AuthContextType = useMemo(

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -6,6 +6,8 @@ import { NavigationProvider } from './navigation.js'
 import type { AuthContextType, AuthProviderProps, LogtoUser } from './types.js'
 
 const POPUP_AUTH_EVENT_DELAY = 500
+const TOKEN_REFRESH_BUFFER_MS = 60_000
+const MIN_TOKEN_REFRESH_DELAY_MS = 1_000
 
 // Create auth context
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
@@ -98,6 +100,10 @@ const InternalAuthProvider = ({
   const transientErrorCount = useRef<number>(0)
   /** Pending exponential-backoff retry timer; cleared on successful load or unmount. */
   const backoffTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>()
+  /** Pending proactive token refresh timer; cleared whenever auth state changes. */
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>()
+  /** Prevents overlapping timer-driven refresh attempts. */
+  const refreshInFlightRef = useRef<boolean>(false)
   /** Set to true in the unmount cleanup; guards async callbacks against firing on dead component. */
   const isUnmountedRef = useRef<boolean>(false)
   /** Tracks the popup-closed polling interval so it can be cleared on provider unmount. */
@@ -112,6 +118,36 @@ const InternalAuthProvider = ({
    */
   const MAX_TRANSIENT_ERRORS = 5
   const MIN_LOAD_INTERVAL = 1000 // 1 second between calls
+
+  const clearRefreshTimer = useCallback(() => {
+    clearTimeout(refreshTimerRef.current)
+    refreshTimerRef.current = undefined
+  }, [])
+
+  const scheduleTokenRefresh = useCallback(
+    (exp?: number) => {
+      clearRefreshTimer()
+
+      if (!isAuthenticated || exp === undefined) {
+        return
+      }
+
+      const refreshDelay = Math.max(exp * 1000 - Date.now() - TOKEN_REFRESH_BUFFER_MS, MIN_TOKEN_REFRESH_DELAY_MS)
+
+      refreshTimerRef.current = setTimeout(() => {
+        if (isUnmountedRef.current || refreshInFlightRef.current) {
+          return
+        }
+
+        refreshInFlightRef.current = true
+
+        void loadUserRef.current(true).finally(() => {
+          refreshInFlightRef.current = false
+        })
+      }, refreshDelay)
+    },
+    [clearRefreshTimer, isAuthenticated],
+  )
 
   const loadUser = useCallback(
     async (forceRefresh?: boolean) => {
@@ -132,6 +168,8 @@ const InternalAuthProvider = ({
         try {
           const claims = await getIdTokenClaims()
           const jwt = await getAccessToken(defaultResource)
+          const tokenExp =
+            typeof claims === 'object' && claims !== null && 'exp' in claims && typeof claims.exp === 'number' ? claims.exp : undefined
 
           if (jwt) {
             // Only set user as logged in if we actually have a valid access token
@@ -141,6 +179,7 @@ const InternalAuthProvider = ({
             errorCount.current = 0
             transientErrorCount.current = 0
             clearTimeout(backoffTimerRef.current)
+            scheduleTokenRefresh(tokenExp)
           } else {
             // Refresh token expired (e.g. user was gone > 30 days) — session is dead.
             // The Logto SDK still reports isAuthenticated=true because it reads stale
@@ -148,6 +187,7 @@ const InternalAuthProvider = ({
             console.warn('Access token unavailable — session likely expired. Forcing logout.')
             setUser(null)
             jwtCookieUtils.removeToken()
+            clearRefreshTimer()
             await logtoSignOut()
           }
         } catch (error: unknown) {
@@ -221,6 +261,7 @@ const InternalAuthProvider = ({
               setUser(null)
               jwtCookieUtils.removeToken()
               transientErrorCount.current = 0
+              clearRefreshTimer()
               try {
                 await logtoSignOut()
               } catch (logoutError) {
@@ -236,6 +277,7 @@ const InternalAuthProvider = ({
             clearTimeout(backoffTimerRef.current)
             setUser(null)
             jwtCookieUtils.removeToken()
+            clearRefreshTimer()
             errorCount.current += 1
             transientErrorCount.current = 0
 
@@ -263,11 +305,12 @@ const InternalAuthProvider = ({
         errorCount.current = 0
         transientErrorCount.current = 0
         clearTimeout(backoffTimerRef.current)
+        clearRefreshTimer()
       }
 
       setIsLoadingUser(false)
     },
-    [defaultResource, getAccessToken, getIdTokenClaims, isAuthenticated, isLoading, logtoSignOut],
+    [clearRefreshTimer, defaultResource, getAccessToken, getIdTokenClaims, isAuthenticated, isLoading, logtoSignOut, scheduleTokenRefresh],
   )
 
   useEffect(() => {
@@ -281,12 +324,13 @@ const InternalAuthProvider = ({
       // on a dead component tree (guards against the timer/unmount race condition).
       isUnmountedRef.current = true
       clearTimeout(backoffTimerRef.current)
+      clearRefreshTimer()
       // Clean up popup polling interval and 5-minute auto-cleanup timer in case
       // the provider is unmounted while a popup sign-in is still in progress.
       clearInterval(popupIntervalRef.current)
       clearTimeout(popupCleanupTimerRef.current)
     }
-  }, [])
+  }, [clearRefreshTimer])
 
   // Store the latest loadUser function in a ref to avoid recreating event listeners
   const loadUserRef = useRef(loadUser)
@@ -480,6 +524,7 @@ const InternalAuthProvider = ({
 
       // Always remove the JWT token cookie on sign out
       jwtCookieUtils.removeToken()
+      clearRefreshTimer()
 
       if (global) {
         // Global sign out - logs out from entire Logto ecosystem
@@ -501,7 +546,7 @@ const InternalAuthProvider = ({
       // Dispatch custom event to notify other windows/tabs
       window.dispatchEvent(new CustomEvent('auth-state-changed'))
     },
-    [logtoSignOut],
+    [clearRefreshTimer, logtoSignOut],
   )
 
   const value: AuthContextType = useMemo(

--- a/tasks-v2.md
+++ b/tasks-v2.md
@@ -279,7 +279,7 @@
 
   > Add a background timer in `AuthProvider` that refreshes the access token shortly before `exp`, avoids duplicate refreshes, clears timers on sign-out/unmount, and is covered by tests for refresh success, refresh failure, and expired refresh-token fallback.
   >
-  > Added a provider-level proactive refresh timer in `src/context.tsx` that schedules a forced auth reload 60 seconds before token expiry (with a 1-second minimum delay for already-near-expiry tokens). The timer is cleared on sign-out, unmount, and unauthenticated transitions, and a `refreshInFlightRef` guard prevents overlapping timer-driven refresh attempts. Added coverage in `src/context.test.tsx` for successful scheduled refresh, auth-error refresh failure, and the null-access-token fallback that forces logout when the refresh token is effectively expired.
+  > Added a provider-level proactive refresh timer in `src/context.tsx` that schedules a forced auth reload 60 seconds before the access token expires, keeping the backend auth cookie aligned with the token actually written to `logto_authtoken`. The timer is cleared on sign-out, unmount, and unauthenticated transitions, and the implementation now guards both against overlapping timer-driven refresh attempts and against tight retry loops when a refresh returns an access token with an unchanged `exp`. Added coverage in `src/context.test.tsx` for access-token-driven scheduling, auth-error refresh failure, the null-access-token fallback that forces logout when the refresh token is effectively expired, and the unchanged-`exp` edge case raised in review.
 
 - [x] **8.4 — Make package scripts cross-platform** NPM scripts should work reliably for contributors on Windows, macOS, and Linux.
 

--- a/tasks-v2.md
+++ b/tasks-v2.md
@@ -275,9 +275,11 @@
   >
   > Added repository-root `SECURITY.md` with a private disclosure policy, supported-version guidance tied to the latest release / current `rc` line, explicit instruction not to file public issues, and two reporting paths: GitHub Security Advisories (when enabled) plus `security@ouim.dev`. Also documented acknowledgement targets, coordinated disclosure expectations, and the package surface covered by the policy.
 
-- [ ] **8.3 — Implement proactive token refresh before expiration** Token refresh is still one of the biggest production-readiness gaps.
+- [x] **8.3 — Implement proactive token refresh before expiration** Token refresh is still one of the biggest production-readiness gaps.
 
   > Add a background timer in `AuthProvider` that refreshes the access token shortly before `exp`, avoids duplicate refreshes, clears timers on sign-out/unmount, and is covered by tests for refresh success, refresh failure, and expired refresh-token fallback.
+  >
+  > Added a provider-level proactive refresh timer in `src/context.tsx` that schedules a forced auth reload 60 seconds before token expiry (with a 1-second minimum delay for already-near-expiry tokens). The timer is cleared on sign-out, unmount, and unauthenticated transitions, and a `refreshInFlightRef` guard prevents overlapping timer-driven refresh attempts. Added coverage in `src/context.test.tsx` for successful scheduled refresh, auth-error refresh failure, and the null-access-token fallback that forces logout when the refresh token is effectively expired.
 
 - [ ] **8.4 — Make package scripts cross-platform** NPM scripts should work reliably for contributors on Windows, macOS, and Linux.
 

--- a/tasks-v2.md
+++ b/tasks-v2.md
@@ -281,9 +281,11 @@
   >
   > Added a provider-level proactive refresh timer in `src/context.tsx` that schedules a forced auth reload 60 seconds before token expiry (with a 1-second minimum delay for already-near-expiry tokens). The timer is cleared on sign-out, unmount, and unauthenticated transitions, and a `refreshInFlightRef` guard prevents overlapping timer-driven refresh attempts. Added coverage in `src/context.test.tsx` for successful scheduled refresh, auth-error refresh failure, and the null-access-token fallback that forces logout when the refresh token is effectively expired.
 
-- [ ] **8.4 — Make package scripts cross-platform** NPM scripts should work reliably for contributors on Windows, macOS, and Linux.
+- [x] **8.4 — Make package scripts cross-platform** NPM scripts should work reliably for contributors on Windows, macOS, and Linux.
 
   > Replace shell-specific commands such as `rm -rf dist` with a cross-platform tool like `rimraf`, then verify the documented commands in `AGENTS.md` / `CONTRIBUTING.md` still work on Windows and on CI Linux.
+  >
+  > Replaced the `clean` script in `package.json` from `rm -rf dist` to `rimraf dist` and added `rimraf` as an explicit devDependency so the script no longer depends on POSIX shell semantics. Verified on Windows by running `npm run clean` and `npm run build`; the documented command names in `AGENTS.md` and `CONTRIBUTING.md` remain accurate because only the underlying implementation changed.
 
 - [x] **8.5 — Add explicit runtime support policy** Production libraries should clearly define supported environments and enforce them where reasonable.
 


### PR DESCRIPTION
Summary
- add proactive token refresh scheduling in AuthProvider based on token exp
- clear refresh timers on sign-out, unmount, and unauthenticated transitions
- add tests for scheduled refresh success, auth-error refresh failure, and expired refresh-token fallback

Verification
- npx vitest run src/context.test.tsx
- npm run lint -- src/context.tsx src/context.test.tsx
- npx tsc --project tsconfig.build.json --noEmit
- npm run build