### PR TITLE
chore: add package audit checks and remove signin reload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    name: Node 24 · Lint · Type-check · Test
+    name: Node 24 · Lint · Type-check · Test · Build
     runs-on: ubuntu-latest
 
     steps:
@@ -36,3 +36,9 @@ jobs:
 
       - name: Test
         run: npx vitest run
+
+      - name: Build
+        run: npm run build
+
+      - name: Package audit
+        run: npm run test:package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Test
         run: npx vitest run
 
+      - name: Build
+        run: npm run build
+
+      - name: Package audit
+        run: npm run test:package
+
       # ── Publish ──────────────────────────────────────────────────────────
       - name: Publish to npm
         run: npm publish --access public --provenance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ npm run build        # Build: vite build + tsc --emitDeclarationOnly
 npm run dev          # Watch TypeScript (no runnable demo app)
 npm run clean        # Remove dist/
 npm test             # Run vitest (watch mode)
+npm run test:package # Audit packed tarball contents + README public imports
 npm run test:smoke   # Pack dist/ and verify consumer fixtures install/build/import from the tarball
 npm run lint         # ESLint
 npm run lint:fix     # ESLint with auto-fix
@@ -22,7 +23,7 @@ npx vitest run src/useAuth.test.tsx
 
 **Before every `git push`**, run the full local CI gate and confirm it passes:
 ```bash
-npm run lint && npx tsc --project tsconfig.build.json --noEmit && npx vitest run && npm run build && npm run test:smoke
+npm run lint && npx tsc --project tsconfig.build.json --noEmit && npx vitest run && npm run build && npm run test:package && npm run test:smoke
 ```
 Do not push if any step fails. Fix the failure first.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,7 @@ npm run lint                                   # ESLint check
 npm run lint:fix                               # ESLint with auto-fix
 npx tsc --project tsconfig.build.json --noEmit # type-check without emitting files
 npm run build                                  # full library build (vite + tsc)
+npm run test:package                           # audit packed tarball files + README imports
 npm run test:smoke                             # pack dist/ and verify consumer fixtures
 ```
 
@@ -98,7 +99,7 @@ There is no local Git hook enforcement in this repository. Conventional Commits 
 2. **Write tests** for any new functionality or bug fix.
 3. **Run the full local CI gate** before pushing:
    ```bash
-   npm run lint && npx tsc --project tsconfig.build.json --noEmit && npx vitest run && npm run build && npm run test:smoke
+   npm run lint && npx tsc --project tsconfig.build.json --noEmit && npx vitest run && npm run build && npm run test:package && npm run test:smoke
    ```
 4. **Open a PR against `rc`** — not `master`.
 5. Ensure the GitHub Actions **CI** workflow passes (the single `Lint · Type-check · Test · Build` job on Node 24 must be green).

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "build:tsc": "tsc",
     "dev": "tsc --watch",
     "test": "vitest",
+    "test:package": "node ./scripts/run-package-audit.mjs",
     "test:smoke": "node ./scripts/run-packed-smoke-tests.mjs",
     "test:coverage": "vitest --coverage",
     "lint": "eslint .",

--- a/scripts/run-package-audit.mjs
+++ b/scripts/run-package-audit.mjs
@@ -1,0 +1,165 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '..')
+const tempRoot = path.join(repoRoot, '.tmp', 'package-audit')
+const artifactDir = path.join(tempRoot, 'artifacts')
+const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const npmRunner = process.env.npm_execpath ? process.execPath : npmExecutable
+
+const packageJson = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8'))
+const readme = readFileSync(path.join(repoRoot, 'readme.md'), 'utf8')
+
+if (!existsSync(path.join(repoRoot, 'dist'))) {
+  fail('Package audit requires an existing dist/ build. Run `npm run build` first.')
+}
+
+rmSync(tempRoot, { recursive: true, force: true })
+mkdirSync(artifactDir, { recursive: true })
+
+const packResult = runCommand(['pack', '--json', '--pack-destination', artifactDir], repoRoot, { captureOutput: true })
+const packEntries = JSON.parse(packResult.stdout)
+const packEntry = Array.isArray(packEntries) ? packEntries[0] : packEntries
+
+if (!packEntry || !Array.isArray(packEntry.files)) {
+  fail('npm pack --json did not return a file listing.')
+}
+
+const packedFiles = new Set(packEntry.files.map(file => file.path))
+const expectedPackedFiles = new Set([
+  'package.json',
+  'readme.md',
+  ...collectPackageEntryFiles(packageJson),
+])
+
+for (const expectedFile of expectedPackedFiles) {
+  if (!packedFiles.has(expectedFile)) {
+    fail(`Packed tarball is missing required file: ${expectedFile}`)
+  }
+}
+
+const allowedImports = new Set(getAllowedPublicImports(packageJson))
+const readmeImports = extractPackageImports(readme, packageJson.name)
+
+for (const specifier of readmeImports) {
+  if (!allowedImports.has(specifier)) {
+    fail(`README references unsupported public import: ${specifier}`)
+  }
+}
+
+console.log(`Package audit passed: ${expectedPackedFiles.size} required packed files, ${readmeImports.size} README import(s).`)
+
+function collectPackageEntryFiles(pkg) {
+  const files = new Set()
+
+  for (const entry of [pkg.main, pkg.module, pkg.types]) {
+    if (typeof entry === 'string' && entry.length > 0) {
+      files.add(stripDotSlash(entry))
+    }
+  }
+
+  if (pkg.exports && typeof pkg.exports === 'object') {
+    for (const value of Object.values(pkg.exports)) {
+      collectExportTargets(value, files)
+    }
+  }
+
+  return [...files]
+}
+
+function collectExportTargets(value, files) {
+  if (typeof value === 'string') {
+    files.add(stripDotSlash(value))
+    return
+  }
+
+  if (!value || typeof value !== 'object') {
+    return
+  }
+
+  for (const nestedValue of Object.values(value)) {
+    collectExportTargets(nestedValue, files)
+  }
+}
+
+function getAllowedPublicImports(pkg) {
+  const imports = [pkg.name]
+
+  if (pkg.exports && typeof pkg.exports === 'object') {
+    for (const exportKey of Object.keys(pkg.exports)) {
+      if (exportKey === '.') {
+        continue
+      }
+
+      imports.push(`${pkg.name}${exportKey.slice(1)}`)
+    }
+  }
+
+  return imports
+}
+
+function extractPackageImports(markdown, packageName) {
+  const codeFencePattern = /```[\w-]*\r?\n([\s\S]*?)```/g
+  const importPattern = new RegExp(`${escapeForRegExp(packageName)}(?:\\/[^"'\\s\`;)]*)?`, 'g')
+  const imports = new Set()
+  let codeFenceMatch
+
+  while ((codeFenceMatch = codeFencePattern.exec(markdown)) !== null) {
+    const block = codeFenceMatch[1]
+    const blockMatches = block.match(importPattern) ?? []
+
+    for (const match of blockMatches) {
+      imports.add(match)
+    }
+  }
+
+  return imports
+}
+
+function escapeForRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function stripDotSlash(value) {
+  return value.replace(/^\.\//, '')
+}
+
+function runCommand(args, cwd, options = {}) {
+  const commandArgs = process.env.npm_execpath ? [process.env.npm_execpath, ...args] : args
+  const result = spawnSync(npmRunner, commandArgs, {
+    cwd,
+    encoding: 'utf8',
+    stdio: options.captureOutput ? 'pipe' : 'inherit',
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0) {
+    if (options.captureOutput) {
+      if (result.stdout) {
+        process.stdout.write(result.stdout)
+      }
+
+      if (result.stderr) {
+        process.stderr.write(result.stderr)
+      }
+    }
+
+    process.exit(result.status ?? 1)
+  }
+
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+function fail(message) {
+  console.error(message)
+  process.exit(1)
+}

--- a/src/signin.test.tsx
+++ b/src/signin.test.tsx
@@ -93,4 +93,34 @@ describe('SignInPage', () => {
       expect(window.location.href).toBe('/')
     })
   })
+
+  it('does not force a reload when an authenticated user is already on /', async () => {
+    const reload = vi.fn()
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: 'https://test.example.com/',
+        pathname: '/',
+        search: '',
+        origin: 'https://test.example.com',
+        reload,
+      },
+      writable: true,
+      configurable: true,
+    })
+
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: 'user-123', name: 'Test User' },
+      isLoadingUser: false,
+      signOut: vi.fn(),
+      refreshAuth: vi.fn(),
+      signIn: vi.fn(),
+    })
+
+    render(<SignInPage />)
+
+    await waitFor(() => {
+      expect(reload).not.toHaveBeenCalled()
+      expect(window.location.href).toBe('https://test.example.com/')
+    })
+  })
 })

--- a/src/signin.tsx
+++ b/src/signin.tsx
@@ -85,8 +85,6 @@ export function SignInPage({ className = '', loadingComponent, errorComponent }:
       } else {
         if (window.location.pathname !== '/') {
           window.location.href = '/'
-        } else {
-          window.location.reload() // Ensure the app state is updated for the authenticated user
         }
       }
       return

--- a/tasks-v2.md
+++ b/tasks-v2.md
@@ -311,9 +311,11 @@
 
   > Start with TTL configurability and explicit cache controls. Only add a pluggable cache adapter if a concrete use case justifies the extra API surface. The first step should be small and testable, not a Redis abstraction by default.
 
-- [ ] **9.2 — Review and remove unnecessary reload behavior in `SignInPage`** Forced reloads should be eliminated or documented as an explicit contract.
+- [x] **9.2 — Review and remove unnecessary reload behavior in `SignInPage`** Forced reloads should be eliminated or documented as an explicit contract.
 
   > `src/signin.tsx` still reloads the page when the user is already authenticated and the current path is `/`. Confirm whether this is actually needed for Logto state synchronization; if not, remove it. If it is needed, document the exact reason and scope so consumers understand the tradeoff.
+  >
+  > Removed the `window.location.reload()` branch from `SignInPage` when an already-authenticated user lands on `/`. The reload was unnecessary because auth state synchronization already happens in `AuthProvider` / `useAuth`; the page only needs to redirect to `/` when it is reached from another route. Added a regression test covering the authenticated-at-root case to ensure the component now stays put without a hard refresh.
 
 - [ ] **9.3 — Add lifecycle callbacks to `AuthProvider`** Hooks for important auth transitions would improve integration with host apps.
 

--- a/tasks-v2.md
+++ b/tasks-v2.md
@@ -293,9 +293,11 @@
   >
   > Added `engines.node` to `package.json` with an explicit supported Node policy (`^18.18.0 || ^20.0.0 || ^22.0.0`), documented the supported Node/React/`@logto/react` ranges in a new `README.md` runtime-support section, and changed GitHub Actions to verify the package on Node 18/20/22. The publish workflow now runs on Node 22 so release automation also stays within the declared support matrix.
 
-- [ ] **8.6 — Add package-content / export audit checks** Public package structure should be validated automatically.
+- [x] **8.6 — Add package-content / export audit checks** Public package structure should be validated automatically.
 
   > Add a CI step that verifies the final tarball contains the expected `dist` files and entrypoints, and that README examples only use supported public imports. This should fail if an export path is removed, renamed, or points at a missing declaration file.
+  >
+  > Added `scripts/run-package-audit.mjs` plus `npm run test:package`. The audit runs `npm pack --json`, verifies the tarball contains the required published metadata files and every file referenced by `main` / `module` / `types` / `exports`, and scans README code fences for `@ouim/simple-logto` imports so unsupported subpaths fail the build. Wired it into both GitHub Actions workflows after `npm run build`, and updated the local gate docs in `AGENTS.md` and `CONTRIBUTING.md` to include the new check.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a package audit step that validates packed export targets and README public imports
- wire the package audit into CI/publish docs and workflows
- remove the redundant window.location.reload() path from SignInPage when an authenticated user is already on /
- add regression coverage for the authenticated-at-root SignInPage case

## Task log
- completed 8.6 — Add package-content / export audit checks
- completed 9.2 — Review and remove unnecessary reload behavior in SignInPage

## Validation
- 
pm run test:package
- 
px vitest run src/signin.test.tsx

## Notes
- 	asks-v2.md was updated and both completed tasks were checked off with implementation comments.