### PR TITLE
Phase 9: JWKS cache controls and auth lifecycle callbacks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,11 +164,27 @@ Props:
 - `callbackUrl?`: default auth callback URL
 - `customNavigate?`: custom navigation function for React Router, Next.js, or other SPA routers
 - `enablePopupSignIn?`: enables popup-based sign-in flow
+- `onTokenRefresh?`: called when an already-authenticated session receives a different access token
+- `onAuthError?`: called when auth loading hits a transient or definitive auth error
+- `onSignOut?`: called immediately before the provider initiates local or global sign-out
 
 Example with custom router navigation:
 
 ```tsx
 <AuthProvider config={logtoConfig} callbackUrl="/callback" customNavigate={url => router.push(url)} enablePopupSignIn>
+  <App />
+</AuthProvider>
+```
+
+Lifecycle callback example:
+
+```tsx
+<AuthProvider
+  config={logtoConfig}
+  onTokenRefresh={({ expiresAt }) => analytics.track('token_refreshed', { expiresAt })}
+  onAuthError={({ error, isTransient }) => console.error('auth error', { message: error.message, isTransient })}
+  onSignOut={({ reason }) => analytics.track('signed_out', { reason })}
+>
   <App />
 </AuthProvider>
 ```

--- a/readme.md
+++ b/readme.md
@@ -342,6 +342,25 @@ const auth = await verifyAuth('your-jwt-token', {
 - `cookieName?`: defaults to `logto_authtoken`
 - `requiredScope?`: rejects requests missing the given scope
 - `allowGuest?`: enables guest auth fallback
+- `jwksCacheTtlMs?`: overrides the default 5 minute in-memory JWKS cache TTL
+- `skipJwksCache?`: bypasses the in-memory JWKS cache for a single verifier/middleware instance
+
+### JWKS cache controls
+
+Backend verification uses a per-process in-memory JWKS cache by default. If you need tighter control during key rotation, debugging, or unusual network setups, you can tune or clear it explicitly:
+
+```ts
+import { clearJwksCache, invalidateJwksCache, verifyAuth } from '@ouim/simple-logto/backend'
+
+await verifyAuth(token, {
+  logtoUrl: 'https://your-tenant.logto.app',
+  audience: 'https://your-api.example.com',
+  jwksCacheTtlMs: 60_000,
+})
+
+invalidateJwksCache('https://your-tenant.logto.app')
+clearJwksCache()
+```
 
 ### Auth context shape
 

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -145,6 +145,30 @@ The verification helpers will look for the JWT token in the following order:
 - `audience`: Your API resource identifier or allowed identifiers (required for protected resource APIs, accepts `string | string[]`)
 - `cookieName`: Custom cookie name (optional, defaults to 'logto_authtoken')
 - `requiredScope`: Required scope for access (optional)
+- `jwksCacheTtlMs`: Override the per-process JWKS cache TTL in milliseconds (optional, defaults to 5 minutes)
+- `skipJwksCache`: Force a fresh JWKS fetch for this verification call instead of reading/writing the in-memory cache (optional)
+
+## JWKS Cache Controls
+
+The backend verifier keeps a per-process in-memory JWKS cache by default. That is usually the right tradeoff, but you can now control it explicitly when needed:
+
+- Pass `jwksCacheTtlMs` to shorten or extend the cache lifetime for a specific verifier/middleware instance.
+- Pass `skipJwksCache: true` to force a fresh JWKS fetch for a specific verification call.
+- Call `invalidateJwksCache(logtoUrl)` to drop one tenant's cached JWKS entry.
+- Call `clearJwksCache()` to flush the entire in-memory JWKS cache for the current process.
+
+```ts
+import { clearJwksCache, invalidateJwksCache, verifyAuth } from '@ouim/simple-logto/backend'
+
+const auth = await verifyAuth(token, {
+  logtoUrl: 'https://your-logto-domain.com',
+  audience: 'your-api-resource-identifier',
+  jwksCacheTtlMs: 60_000,
+})
+
+invalidateJwksCache('https://your-logto-domain.com')
+clearJwksCache()
+```
 
 ## Auth Context
 

--- a/src/backend/express.integration.test.ts
+++ b/src/backend/express.integration.test.ts
@@ -188,4 +188,28 @@ describe('createExpressAuthMiddleware integration', () => {
     })
     expect(response.body.message).toContain('Missing required scope: write:user')
   })
+
+  it('honors skipJwksCache through the Express middleware wrapper', async () => {
+    const logtoUrl = 'https://test.logto.app/express-skip-cache'
+    vi.mocked(jwtVerify).mockResolvedValue({
+      payload: buildPayload(logtoUrl),
+      protectedHeader: {},
+    } as never)
+
+    const app = buildApp({
+      logtoUrl,
+      audience: 'urn:logto:resource:api',
+      skipJwksCache: true,
+    })
+
+    await request(app)
+      .get('/session')
+      .set('Cookie', [`logto_authtoken=${validToken}`])
+
+    await request(app)
+      .get('/session')
+      .set('Cookie', [`logto_authtoken=${validToken}`])
+
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/backend/next-route.integration.test.ts
+++ b/src/backend/next-route.integration.test.ts
@@ -209,4 +209,43 @@ describe('verifyNextAuth route handler integration', () => {
       error: 'No token found in cookies or Authorization header',
     })
   })
+
+  it('honors jwksCacheTtlMs through verifyNextAuth route handling', async () => {
+    const logtoUrl = 'https://test.logto.app/next-custom-ttl'
+    vi.useFakeTimers()
+    try {
+      vi.mocked(jwtVerify).mockResolvedValue({
+        payload: buildPayload(logtoUrl),
+        protectedHeader: {},
+      } as never)
+
+      await routeHandler(
+        createRouteRequest({
+          cookie: `logto_authtoken=${validToken}`,
+        }),
+        {
+          logtoUrl,
+          audience: 'urn:logto:resource:api',
+          jwksCacheTtlMs: 1,
+        },
+      )
+
+      vi.advanceTimersByTime(5)
+
+      await routeHandler(
+        createRouteRequest({
+          cookie: `logto_authtoken=${validToken}`,
+        }),
+        {
+          logtoUrl,
+          audience: 'urn:logto:resource:api',
+          jwksCacheTtlMs: 1,
+        },
+      )
+
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -23,6 +23,8 @@ export interface VerifyAuthOptions {
   cookieName?: string
   requiredScope?: string
   allowGuest?: boolean
+  jwksCacheTtlMs?: number
+  skipJwksCache?: boolean
 }
 
 // Express middleware types

--- a/src/backend/verify-auth.test.ts
+++ b/src/backend/verify-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { verifyLogtoToken } from './verify-auth'
+import { clearJwksCache, invalidateJwksCache, verifyLogtoToken } from './verify-auth'
 import type { VerifyAuthOptions } from './types'
 
 // Mock jose library
@@ -21,6 +21,7 @@ describe('JWT Verification Logic', () => {
     // resetAllMocks() clears both call history AND the mockResolvedValueOnce queue.
     // clearAllMocks() only clears call history — stale queued values bleed across tests.
     vi.resetAllMocks()
+    clearJwksCache()
   })
 
   describe('Token Format Validation', () => {
@@ -195,6 +196,107 @@ describe('JWT Verification Logic', () => {
       expect(global.fetch).toHaveBeenCalledTimes(2)
       expect(result.isAuthenticated).toBe(true)
       expect(result.userId).toBe('user-123')
+    })
+
+    it('should honor a custom JWKS cache TTL', async () => {
+      vi.useFakeTimers()
+      try {
+        const cacheUrl = 'https://cache-custom-ttl-test.logto.app'
+        const cacheOptions: VerifyAuthOptions = {
+          logtoUrl: cacheUrl,
+          audience: 'urn:logto:resource:api',
+          jwksCacheTtlMs: 1000,
+        }
+        const mockToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2lkIn0.payload.signature'
+        const mockJwks = {
+          ok: true,
+          json: async () => ({ keys: [{ kid: 'test-kid', kty: 'RSA', n: 'n', e: 'AQAB' }] }),
+        }
+        const makePayload = () => ({
+          sub: 'user-custom-ttl',
+          iss: `${cacheUrl}/oidc`,
+          aud: 'urn:logto:resource:api',
+          exp: Math.floor(Date.now() / 1000) + 3600,
+        })
+
+        const { jwtVerify } = await import('jose')
+
+        ;(global.fetch as any).mockResolvedValueOnce(mockJwks)
+        ;(jwtVerify as any).mockResolvedValueOnce({ payload: makePayload() })
+        await verifyLogtoToken(mockToken, cacheOptions)
+
+        vi.advanceTimersByTime(1500)
+
+        ;(global.fetch as any).mockResolvedValueOnce(mockJwks)
+        ;(jwtVerify as any).mockResolvedValueOnce({ payload: makePayload() })
+        await verifyLogtoToken(mockToken, cacheOptions)
+
+        expect(global.fetch).toHaveBeenCalledTimes(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('should bypass the JWKS cache when skipJwksCache is true', async () => {
+      const cacheUrl = 'https://cache-skip-test.logto.app'
+      const cacheOptions: VerifyAuthOptions = {
+        logtoUrl: cacheUrl,
+        audience: 'urn:logto:resource:api',
+        skipJwksCache: true,
+      }
+      const mockToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2lkIn0.payload.signature'
+      const mockJwks = {
+        ok: true,
+        json: async () => ({ keys: [{ kid: 'test-kid', kty: 'RSA', n: 'n', e: 'AQAB' }] }),
+      }
+      const makePayload = () => ({
+        sub: 'user-skip-cache',
+        iss: `${cacheUrl}/oidc`,
+        aud: 'urn:logto:resource:api',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      })
+
+      const { jwtVerify } = await import('jose')
+
+      ;(global.fetch as any).mockResolvedValueOnce(mockJwks)
+      ;(jwtVerify as any).mockResolvedValueOnce({ payload: makePayload() })
+      await verifyLogtoToken(mockToken, cacheOptions)
+
+      ;(global.fetch as any).mockResolvedValueOnce(mockJwks)
+      ;(jwtVerify as any).mockResolvedValueOnce({ payload: makePayload() })
+      await verifyLogtoToken(mockToken, cacheOptions)
+
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should let callers explicitly invalidate a tenant JWKS cache entry', async () => {
+      const cacheUrl = 'https://cache-explicit-invalidate-test.logto.app'
+      const cacheOptions: VerifyAuthOptions = { logtoUrl: cacheUrl, audience: 'urn:logto:resource:api' }
+      const mockToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2lkIn0.payload.signature'
+      const mockJwks = {
+        ok: true,
+        json: async () => ({ keys: [{ kid: 'test-kid', kty: 'RSA', n: 'n', e: 'AQAB' }] }),
+      }
+      const makePayload = () => ({
+        sub: 'user-explicit-invalidate',
+        iss: `${cacheUrl}/oidc`,
+        aud: 'urn:logto:resource:api',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      })
+
+      const { jwtVerify } = await import('jose')
+
+      ;(global.fetch as any).mockResolvedValueOnce(mockJwks)
+      ;(jwtVerify as any).mockResolvedValueOnce({ payload: makePayload() })
+      await verifyLogtoToken(mockToken, cacheOptions)
+
+      invalidateJwksCache(cacheUrl)
+
+      ;(global.fetch as any).mockResolvedValueOnce(mockJwks)
+      ;(jwtVerify as any).mockResolvedValueOnce({ payload: makePayload() })
+      await verifyLogtoToken(mockToken, cacheOptions)
+
+      expect(global.fetch).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/src/backend/verify-auth.ts
+++ b/src/backend/verify-auth.ts
@@ -35,7 +35,7 @@ function isHeaderMap(headers: unknown): headers is HeaderMap {
 
 // Cache for JWKs to avoid fetching on every request
 const jwksCache = new Map<string, { keys: JwkKey[]; expires: number }>()
-const CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
+const DEFAULT_JWKS_CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
 
 /**
  * Normalize a Logto base URL to its OIDC base path.
@@ -125,13 +125,14 @@ function base64UrlDecode(str: string): string {
 /**
  * Fetch JWKS from Logto server with caching
  */
-async function fetchJWKS(logtoUrl: string): Promise<JwkKey[]> {
-  const jwksUrl = `${buildOidcBaseUrl(logtoUrl)}/jwks`
+async function fetchJWKS(options: Pick<VerifyAuthOptions, 'logtoUrl' | 'jwksCacheTtlMs' | 'skipJwksCache'>): Promise<JwkKey[]> {
+  const { logtoUrl, jwksCacheTtlMs = DEFAULT_JWKS_CACHE_TTL_MS, skipJwksCache = false } = options
+  const jwksUrl = getJwksUrl(logtoUrl)
   const now = Date.now()
 
   // Check cache first
   const cached = jwksCache.get(jwksUrl)
-  if (cached && cached.expires > now) {
+  if (!skipJwksCache && cached && cached.expires > now) {
     return cached.keys
   }
 
@@ -144,16 +145,45 @@ async function fetchJWKS(logtoUrl: string): Promise<JwkKey[]> {
     const jwks = await response.json()
     const keys = jwks.keys || []
 
-    // Cache the keys
-    jwksCache.set(jwksUrl, {
-      keys,
-      expires: now + CACHE_DURATION,
-    })
+    if (!skipJwksCache && jwksCacheTtlMs > 0) {
+      jwksCache.set(jwksUrl, {
+        keys,
+        expires: now + jwksCacheTtlMs,
+      })
+    } else {
+      jwksCache.delete(jwksUrl)
+    }
 
     return keys
   } catch (error) {
     throw new Error(`Failed to fetch JWKS from ${jwksUrl}: ${error instanceof Error ? error.message : 'Unknown error'}`)
   }
+}
+
+function getJwksUrl(logtoUrl: string): string {
+  return `${buildOidcBaseUrl(logtoUrl)}/jwks`
+}
+
+/**
+ * Remove the cached JWKS entry for a specific Logto tenant.
+ *
+ * Useful after rotating signing keys, changing proxy/network configuration,
+ * or when an operator wants the next verification to force a fresh JWKS fetch.
+ *
+ * @param {string} logtoUrl - Logto server URL whose JWKS cache entry should be removed.
+ */
+export function invalidateJwksCache(logtoUrl: string): void {
+  jwksCache.delete(getJwksUrl(logtoUrl))
+}
+
+/**
+ * Clear all cached JWKS entries held in this process.
+ *
+ * Useful in tests, long-lived worker processes, or admin/debug flows where
+ * you want the next verification for every tenant to fetch fresh keys.
+ */
+export function clearJwksCache(): void {
+  jwksCache.clear()
 }
 
 /**
@@ -358,7 +388,7 @@ async function verifyWithKeys(
  *
  * Verifies a Logto JWT token by:
  * 1. Decoding the JWT header to extract key ID (kid) and algorithm
- * 2. Fetching the JWKS (JSON Web Key Set) from Logto's OIDC endpoint (cached, 5 min TTL)
+ * 2. Fetching the JWKS (JSON Web Key Set) from Logto's OIDC endpoint (cached, default 5 min TTL)
  * 3. Finding the matching public key
  * 4. Verifying the token signature
  * 5. Validating the payload shape (all required/typed fields present)
@@ -376,6 +406,8 @@ async function verifyWithKeys(
  * @param {string} [options.requiredScope] - Required scope that must be present in token
  * @param {string} [options.cookieName] - Cookie name for token storage (default: 'logto_authtoken')
  * @param {boolean} [options.allowGuest] - Allow unauthenticated guest access
+ * @param {number} [options.jwksCacheTtlMs=300000] - How long to cache fetched JWKS keys in memory per process
+ * @param {boolean} [options.skipJwksCache=false] - When true, bypass the in-memory JWKS cache for this verification call
  *
  * @returns {Promise<AuthContext>} Authentication context with user ID, authentication status, and token payload
  *
@@ -396,7 +428,7 @@ export async function verifyLogtoToken(token: string, options: VerifyAuthOptions
   const { logtoUrl } = options
   // Derive the JWKS URL via the shared helper so this matches the cache key
   // used by fetchJWKS — guarantees the delete() on retry hits the right entry.
-  const jwksUrl = `${buildOidcBaseUrl(logtoUrl)}/jwks`
+  const jwksUrl = getJwksUrl(logtoUrl)
 
   try {
     // Decode JWT header to get kid and alg
@@ -409,7 +441,7 @@ export async function verifyLogtoToken(token: string, options: VerifyAuthOptions
     const header = JSON.parse(headerJson) as Record<string, unknown>
 
     // Fetch JWKS from Logto (uses in-memory cache when within 5-minute TTL)
-    const keys = await fetchJWKS(logtoUrl)
+    const keys = await fetchJWKS(options)
 
     try {
       return await verifyWithKeys(token, header, keys, options)
@@ -424,7 +456,7 @@ export async function verifyLogtoToken(token: string, options: VerifyAuthOptions
       // Invalidate the stale cache entry and fetch a fresh JWKS, then retry once.
       console.warn('[verifyLogtoToken] Key/signature error — invalidating JWKS cache and retrying with fresh keys')
       jwksCache.delete(jwksUrl)
-      const freshKeys = await fetchJWKS(logtoUrl)
+      const freshKeys = await fetchJWKS(options)
       return await verifyWithKeys(token, header, freshKeys, options)
     }
   } catch (error) {

--- a/src/context.test.tsx
+++ b/src/context.test.tsx
@@ -647,6 +647,27 @@ describe('AuthProvider Lifecycle Callbacks', () => {
     })
     expect(logtoSignOut).not.toHaveBeenCalled()
   })
+
+  it('swallows errors thrown by consumer lifecycle callbacks without breaking sign-out', async () => {
+    const onSignOut = vi.fn(() => {
+      throw new Error('consumer callback failure')
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <AuthProvider config={mockConfig} onSignOut={onSignOut}>
+        <AuthControls />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByText('Sign Out')).toBeInTheDocument())
+    expect(() => fireEvent.click(screen.getByText('Sign Out'))).not.toThrow()
+
+    await waitFor(() => expect(onSignOut).toHaveBeenCalledTimes(1))
+    expect(errorSpy).toHaveBeenCalledWith('Error in AuthProvider onSignOut callback:', expect.any(Error))
+
+    errorSpy.mockRestore()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/context.test.tsx
+++ b/src/context.test.tsx
@@ -515,6 +515,138 @@ describe('Proactive Token Refresh', () => {
 
     expect(getAccessToken).toHaveBeenCalledTimes(2)
   }, 10000)
+
+  it('calls onTokenRefresh when a scheduled refresh replaces the access token', async () => {
+    const initialAccessTokenExp = Math.floor(Date.now() / 1000) + 61
+    const refreshedAccessTokenExp = Math.floor(Date.now() / 1000) + 300
+    const onTokenRefresh = vi.fn()
+    const getIdTokenClaims = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sub: 'user-123',
+        name: 'Test User',
+        email: 'test@example.com',
+      })
+      .mockResolvedValueOnce({
+        sub: 'user-123',
+        name: 'Test User',
+        email: 'test@example.com',
+      })
+    const getAccessToken = vi
+      .fn()
+      .mockResolvedValueOnce(createMockJwt(initialAccessTokenExp))
+      .mockResolvedValueOnce(createMockJwt(refreshedAccessTokenExp))
+
+    vi.mocked(useLogto).mockReturnValue(
+      createMockLogtoContext({
+        isAuthenticated: true,
+        getIdTokenClaims,
+        getAccessToken,
+      }),
+    )
+
+    render(
+      <AuthProvider config={mockConfig} onTokenRefresh={onTokenRefresh}>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByText('user: user-123')).toBeInTheDocument())
+    await waitFor(() => expect(onTokenRefresh).toHaveBeenCalledTimes(1), { timeout: 3000 })
+
+    expect(onTokenRefresh).toHaveBeenCalledWith({
+      user: {
+        id: 'user-123',
+        name: 'Test User',
+        email: 'test@example.com',
+      },
+      accessToken: createMockJwt(refreshedAccessTokenExp),
+      expiresAt: refreshedAccessTokenExp,
+      previousExpiresAt: initialAccessTokenExp,
+    })
+  }, 10000)
+})
+
+describe('AuthProvider Lifecycle Callbacks', () => {
+  const AuthControls = () => {
+    const { signOut } = useAuthContext()
+    return <button onClick={() => signOut({ callbackUrl: '/signed-out', global: false })}>Sign Out</button>
+  }
+
+  it('calls onAuthError before a forced logout caused by an auth failure', async () => {
+    const onAuthError = vi.fn()
+    const onSignOut = vi.fn()
+    const initialExp = Math.floor(Date.now() / 1000) + 61
+    const getIdTokenClaims = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sub: 'user-123',
+        name: 'Test User',
+        email: 'test@example.com',
+      })
+      .mockRejectedValueOnce(new Error('invalid_grant'))
+    const getAccessToken = vi.fn().mockResolvedValueOnce(createMockJwt(initialExp))
+    const signOut = vi.fn()
+
+    vi.mocked(useLogto).mockReturnValue(
+      createMockLogtoContext({
+        isAuthenticated: true,
+        getIdTokenClaims,
+        getAccessToken,
+        signOut,
+      }),
+    )
+
+    render(
+      <AuthProvider config={mockConfig} onAuthError={onAuthError} onSignOut={onSignOut}>
+        <div>test</div>
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(onAuthError).toHaveBeenCalledTimes(1), { timeout: 3000 })
+    await waitFor(() => expect(onSignOut).toHaveBeenCalledTimes(1), { timeout: 3000 })
+
+    expect(onAuthError).toHaveBeenCalledWith({
+      error: expect.objectContaining({ message: 'invalid_grant' }),
+      isTransient: false,
+      willSignOut: true,
+    })
+    expect(onSignOut).toHaveBeenCalledWith({
+      reason: 'auth_error',
+      global: true,
+      callbackUrl: undefined,
+      error: expect.objectContaining({ message: 'invalid_grant' }),
+    })
+  }, 10000)
+
+  it('calls onSignOut for an explicit user sign-out with the selected scope', async () => {
+    const onSignOut = vi.fn()
+    const logtoSignOut = vi.fn()
+
+    vi.mocked(useLogto).mockReturnValue(
+      createMockLogtoContext({
+        isAuthenticated: true,
+        signOut: logtoSignOut,
+      }),
+    )
+
+    render(
+      <AuthProvider config={mockConfig} onSignOut={onSignOut}>
+        <AuthControls />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByText('Sign Out')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Sign Out'))
+
+    await waitFor(() => expect(onSignOut).toHaveBeenCalledTimes(1))
+    expect(onSignOut).toHaveBeenCalledWith({
+      reason: 'user',
+      global: false,
+      callbackUrl: '/signed-out',
+    })
+    expect(logtoSignOut).not.toHaveBeenCalled()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -3,7 +3,7 @@ import React, { createContext, useContext, useEffect, useState, useCallback, use
 import { LogtoConfig, LogtoProvider, useLogto } from '@logto/react'
 import { transformUser, jwtCookieUtils, guestUtils, validateLogtoConfig } from './utils.js'
 import { NavigationProvider } from './navigation.js'
-import type { AuthContextType, AuthProviderProps, LogtoUser } from './types.js'
+import type { AuthContextType, AuthErrorEvent, AuthProviderProps, AuthSignOutEvent, AuthSignOutReason, AuthTokenRefreshEvent, LogtoUser } from './types.js'
 
 const POPUP_AUTH_EVENT_DELAY = 500
 const TOKEN_REFRESH_BUFFER_MS = 60_000
@@ -43,6 +43,8 @@ const getJwtExpiration = (token: string): number | undefined => {
     return undefined
   }
 }
+
+const toError = (error: unknown): Error => (error instanceof Error ? error : new Error(String(error)))
 
 // Create auth context
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
@@ -112,11 +114,17 @@ const InternalAuthProvider = ({
   callbackUrl,
   enablePopupSignIn,
   logtoConfig,
+  onTokenRefresh,
+  onAuthError,
+  onSignOut,
 }: {
   children: React.ReactNode
   callbackUrl?: string
   enablePopupSignIn?: boolean
   logtoConfig: LogtoConfig // Logto configuration object
+  onTokenRefresh?: (event: AuthTokenRefreshEvent) => void
+  onAuthError?: (event: AuthErrorEvent) => void
+  onSignOut?: (event: AuthSignOutEvent) => void
 }) => {
   const { isAuthenticated, isLoading, getIdTokenClaims, getAccessToken, signIn: logtoSignIn, signOut: logtoSignOut } = useLogto()
   const [user, setUser] = useState<LogtoUser | null>(null)
@@ -147,6 +155,14 @@ const InternalAuthProvider = ({
   const popupIntervalRef = useRef<ReturnType<typeof setInterval> | undefined>()
   /** Tracks the 5-minute popup auto-cleanup timer so it can be cleared on provider unmount. */
   const popupCleanupTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>()
+  /** Tracks the last access token so refresh callbacks only fire for real token transitions. */
+  const lastAccessTokenRef = useRef<string | undefined>()
+  /** Tracks the last access token expiry used in refresh callback payloads. */
+  const lastAccessTokenExpRef = useRef<number | undefined>()
+  /** Latest lifecycle callbacks without forcing auth logic to re-subscribe on every render. */
+  const onTokenRefreshRef = useRef(onTokenRefresh)
+  const onAuthErrorRef = useRef(onAuthError)
+  const onSignOutRef = useRef(onSignOut)
   const MAX_ERROR_COUNT = 3
   /**
    * Maximum consecutive transient errors before giving up and signing the user out.
@@ -155,6 +171,60 @@ const InternalAuthProvider = ({
    */
   const MAX_TRANSIENT_ERRORS = 5
   const MIN_LOAD_INTERVAL = 1000 // 1 second between calls
+
+  useEffect(() => {
+    onTokenRefreshRef.current = onTokenRefresh
+  }, [onTokenRefresh])
+
+  useEffect(() => {
+    onAuthErrorRef.current = onAuthError
+  }, [onAuthError])
+
+  useEffect(() => {
+    onSignOutRef.current = onSignOut
+  }, [onSignOut])
+
+  const emitAuthError = useCallback((event: AuthErrorEvent) => {
+    try {
+      onAuthErrorRef.current?.(event)
+    } catch (callbackError) {
+      console.error('Error in AuthProvider onAuthError callback:', callbackError)
+    }
+  }, [])
+
+  const emitSignOut = useCallback((event: AuthSignOutEvent) => {
+    try {
+      onSignOutRef.current?.(event)
+    } catch (callbackError) {
+      console.error('Error in AuthProvider onSignOut callback:', callbackError)
+    }
+  }, [])
+
+  const emitTokenRefresh = useCallback((event: AuthTokenRefreshEvent) => {
+    try {
+      onTokenRefreshRef.current?.(event)
+    } catch (callbackError) {
+      console.error('Error in AuthProvider onTokenRefresh callback:', callbackError)
+    }
+  }, [])
+
+  const clearTrackedAccessToken = useCallback(() => {
+    lastAccessTokenRef.current = undefined
+    lastAccessTokenExpRef.current = undefined
+  }, [])
+
+  const performGlobalSignOut = useCallback(
+    async (reason: AuthSignOutReason, error?: Error, nextCallbackUrl?: string) => {
+      emitSignOut({
+        reason,
+        global: true,
+        callbackUrl: nextCallbackUrl,
+        error,
+      })
+      await logtoSignOut(nextCallbackUrl)
+    },
+    [emitSignOut, logtoSignOut],
+  )
 
   const clearRefreshTimer = useCallback(() => {
     clearTimeout(refreshTimerRef.current)
@@ -226,27 +296,48 @@ const InternalAuthProvider = ({
           const jwt = await getAccessToken(defaultResource)
 
           if (jwt) {
+            const nextUser = transformUser(claims)
             // Only set user as logged in if we actually have a valid access token
             const tokenExp = getJwtExpiration(jwt)
+            const previousToken = lastAccessTokenRef.current
+            const previousExpiresAt = lastAccessTokenExpRef.current
             jwtCookieUtils.saveToken(jwt)
-            setUser(transformUser(claims))
+            setUser(nextUser)
             // Reset all error counters and any pending backoff on a successful fetch
             errorCount.current = 0
             transientErrorCount.current = 0
             clearTimeout(backoffTimerRef.current)
+            lastAccessTokenRef.current = jwt
+            lastAccessTokenExpRef.current = tokenExp
+            if (previousToken !== undefined && previousToken !== jwt && nextUser) {
+              emitTokenRefresh({
+                user: nextUser,
+                accessToken: jwt,
+                expiresAt: tokenExp,
+                previousExpiresAt,
+              })
+            }
             scheduleTokenRefresh(tokenExp)
           } else {
             // Refresh token expired (e.g. user was gone > 30 days) — session is dead.
             // The Logto SDK still reports isAuthenticated=true because it reads stale
             // localStorage, but we have no usable token, so we must log out cleanly.
-            console.warn('Access token unavailable — session likely expired. Forcing logout.')
+            const authError = new Error('Access token unavailable — session likely expired. Forcing logout.')
+            console.warn(authError.message)
+            emitAuthError({
+              error: authError,
+              isTransient: false,
+              willSignOut: true,
+            })
             setUser(null)
             jwtCookieUtils.removeToken()
             resetRefreshSchedule()
-            await logtoSignOut()
+            clearTrackedAccessToken()
+            await performGlobalSignOut('missing_access_token', authError)
           }
         } catch (error: unknown) {
           console.error('Error fetching user claims:', error)
+          const normalizedError = toError(error)
 
           // ─── Classify the error ──────────────────────────────────────────────
           //
@@ -256,7 +347,7 @@ const InternalAuthProvider = ({
           //
           // Auth errors (invalid/expired tokens, revoked grants) indicate the
           // session is genuinely broken and we must sign the user out.
-          const errorMessage = error instanceof Error ? error.message.toLowerCase() : ''
+          const errorMessage = normalizedError.message.toLowerCase()
           const errorCode = typeof error === 'object' && error !== null && 'code' in error ? (error as { code: unknown }).code : undefined
 
           // Auth errors are evaluated FIRST because they must take priority:
@@ -291,6 +382,12 @@ const InternalAuthProvider = ({
           // ─── Transient error path ────────────────────────────────────────────
           if (isTransientError) {
             transientErrorCount.current += 1
+            const willSignOut = transientErrorCount.current > MAX_TRANSIENT_ERRORS
+            emitAuthError({
+              error: normalizedError,
+              isTransient: true,
+              willSignOut,
+            })
             // Preserve the current user state — the user is likely still authenticated.
             // Schedule an exponential-backoff retry (capped at 32 s) so that a
             // temporary outage self-heals without manual intervention.
@@ -317,8 +414,9 @@ const InternalAuthProvider = ({
               jwtCookieUtils.removeToken()
               transientErrorCount.current = 0
               resetRefreshSchedule()
+              clearTrackedAccessToken()
               try {
-                await logtoSignOut()
+                await performGlobalSignOut('transient_error_limit', normalizedError)
               } catch (logoutError) {
                 console.error('Error during forced logout after transient retry exhaustion:', logoutError)
                 if (typeof window !== 'undefined') {
@@ -337,11 +435,17 @@ const InternalAuthProvider = ({
             transientErrorCount.current = 0
 
             const shouldSignOut = isDefiniteAuthError || errorCount.current >= MAX_ERROR_COUNT
+            emitAuthError({
+              error: normalizedError,
+              isTransient: false,
+              willSignOut: shouldSignOut,
+            })
 
             if (shouldSignOut) {
-              console.warn('Authentication error detected, forcing logout:', error instanceof Error ? error.message : error)
+              console.warn('Authentication error detected, forcing logout:', normalizedError.message)
+              clearTrackedAccessToken()
               try {
-                await logtoSignOut()
+                await performGlobalSignOut('auth_error', normalizedError)
               } catch (logoutError) {
                 console.error('Error during forced logout:', logoutError)
                 if (typeof window !== 'undefined') {
@@ -356,6 +460,7 @@ const InternalAuthProvider = ({
         setUser(null)
         // Remove token cookie when not authenticated
         jwtCookieUtils.removeToken()
+        clearTrackedAccessToken()
         // Reset all error counts when transitioning to unauthenticated state
         errorCount.current = 0
         transientErrorCount.current = 0
@@ -365,7 +470,7 @@ const InternalAuthProvider = ({
 
       setIsLoadingUser(false)
     },
-    [defaultResource, getAccessToken, getIdTokenClaims, isAuthenticated, isLoading, logtoSignOut, resetRefreshSchedule, scheduleTokenRefresh],
+    [clearTrackedAccessToken, defaultResource, emitAuthError, emitTokenRefresh, getAccessToken, getIdTokenClaims, isAuthenticated, isLoading, performGlobalSignOut, resetRefreshSchedule, scheduleTokenRefresh],
   )
 
   useEffect(() => {
@@ -580,6 +685,12 @@ const InternalAuthProvider = ({
       // Always remove the JWT token cookie on sign out
       jwtCookieUtils.removeToken()
       resetRefreshSchedule()
+      clearTrackedAccessToken()
+      emitSignOut({
+        reason: 'user',
+        global,
+        callbackUrl,
+      })
 
       if (global) {
         // Global sign out - logs out from entire Logto ecosystem
@@ -601,7 +712,7 @@ const InternalAuthProvider = ({
       // Dispatch custom event to notify other windows/tabs
       window.dispatchEvent(new CustomEvent('auth-state-changed'))
     },
-    [logtoSignOut, resetRefreshSchedule],
+    [clearTrackedAccessToken, emitSignOut, logtoSignOut, resetRefreshSchedule],
   )
 
   const value: AuthContextType = useMemo(
@@ -631,6 +742,9 @@ const InternalAuthProvider = ({
  * @param {string} [callbackUrl] - Default URL to redirect to after authentication (e.g., '/dashboard'). Can be overridden per sign-in call
  * @param {Function} [customNavigate] - Custom navigation function for client-side routing (e.g., from React Router or Next.js). If not provided, uses window.location
  * @param {boolean} [enablePopupSignIn=false] - Enable popup-based sign-in flow (opens sign-in in a new window). Defaults to redirect flow
+ * @param {(event: AuthTokenRefreshEvent) => void} [onTokenRefresh] - Called when an existing authenticated session receives a different access token
+ * @param {(event: AuthErrorEvent) => void} [onAuthError] - Called when auth loading hits a transient or definitive auth error
+ * @param {(event: AuthSignOutEvent) => void} [onSignOut] - Called immediately before the provider initiates local or global sign-out
  *
  * @example
  * // Basic setup with Logto configuration
@@ -659,7 +773,16 @@ const InternalAuthProvider = ({
  * @throws {Error} If required Logto configuration is missing or invalid (endpoint, appId)
  */
 // External provider that wraps Logto's provider
-export const AuthProvider = ({ children, config, callbackUrl, customNavigate, enablePopupSignIn = false }: AuthProviderProps) => {
+export const AuthProvider = ({
+  children,
+  config,
+  callbackUrl,
+  customNavigate,
+  enablePopupSignIn = false,
+  onTokenRefresh,
+  onAuthError,
+  onSignOut,
+}: AuthProviderProps) => {
   // Validate configuration on mount; also emit developer-friendly warnings in non-production
   // builds so misconfiguration is caught early with actionable messages and doc links.
   useEffect(() => {
@@ -696,7 +819,14 @@ export const AuthProvider = ({ children, config, callbackUrl, customNavigate, en
     <ClientOnly>
       <LogtoProvider config={config}>
         <NavigationProvider customNavigate={customNavigate}>
-          <InternalAuthProvider logtoConfig={config} callbackUrl={callbackUrl} enablePopupSignIn={enablePopupSignIn}>
+          <InternalAuthProvider
+            logtoConfig={config}
+            callbackUrl={callbackUrl}
+            enablePopupSignIn={enablePopupSignIn}
+            onTokenRefresh={onTokenRefresh}
+            onAuthError={onAuthError}
+            onSignOut={onSignOut}
+          >
             {children}
           </InternalAuthProvider>
         </NavigationProvider>

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,12 +32,37 @@ export interface AuthContextType {
   enablePopupSignIn?: boolean
 }
 
+export type AuthSignOutReason = 'user' | 'auth_error' | 'missing_access_token' | 'transient_error_limit'
+
+export interface AuthTokenRefreshEvent {
+  user: LogtoUser
+  accessToken: string
+  expiresAt?: number
+  previousExpiresAt?: number
+}
+
+export interface AuthErrorEvent {
+  error: Error
+  isTransient: boolean
+  willSignOut: boolean
+}
+
+export interface AuthSignOutEvent {
+  reason: AuthSignOutReason
+  global: boolean
+  callbackUrl?: string
+  error?: Error
+}
+
 export interface AuthProviderProps {
   children: React.ReactNode
   config: LogtoConfig
   callbackUrl?: string
   customNavigate?: (url: string, options?: NavigationOptions) => void
   enablePopupSignIn?: boolean
+  onTokenRefresh?: (event: AuthTokenRefreshEvent) => void
+  onAuthError?: (event: AuthErrorEvent) => void
+  onSignOut?: (event: AuthSignOutEvent) => void
 }
 
 export interface CallbackPageProps {

--- a/tasks-v2.md
+++ b/tasks-v2.md
@@ -319,9 +319,11 @@
   >
   > Removed the `window.location.reload()` branch from `SignInPage` when an already-authenticated user lands on `/`. The reload was unnecessary because auth state synchronization already happens in `AuthProvider` / `useAuth`; the page only needs to redirect to `/` when it is reached from another route. Added a regression test covering the authenticated-at-root case to ensure the component now stays put without a hard refresh.
 
-- [ ] **9.3 — Add lifecycle callbacks to `AuthProvider`** Hooks for important auth transitions would improve integration with host apps.
+- [x] **9.3 — Add lifecycle callbacks to `AuthProvider`** Hooks for important auth transitions would improve integration with host apps.
 
   > Add well-scoped callbacks such as `onTokenRefresh`, `onAuthError`, and `onSignOut`, with clear guarantees around when they fire and what data they receive. Avoid a generic event bus.
+  >
+  > Added `onTokenRefresh`, `onAuthError`, and `onSignOut` to `AuthProviderProps` with explicit event payload types in `src/types.ts` instead of a generic emitter. `onTokenRefresh` only fires when an already-loaded authenticated session receives a different access token; `onAuthError` reports both transient and definitive auth failures with a `willSignOut` flag; and `onSignOut` fires immediately before the provider initiates local or global sign-out, including the reason (`user`, `auth_error`, `missing_access_token`, `transient_error_limit`). Added focused context tests for refresh and sign-out/error flows and documented the callbacks in the public README.
 
 - [ ] **9.4 — Improve SSR/client boundary documentation and helpers** The package uses client-only guards in several places; consumers need clearer guidance.
 

--- a/tasks-v2.md
+++ b/tasks-v2.md
@@ -307,9 +307,11 @@
 
 **Priority: 🟡 Medium**
 
-- [ ] **9.1 — Make JWKS cache configurable** The current module-level in-memory cache is reasonable for many apps, but not ideal everywhere.
+- [x] **9.1 — Make JWKS cache configurable** The current module-level in-memory cache is reasonable for many apps, but not ideal everywhere.
 
   > Start with TTL configurability and explicit cache controls. Only add a pluggable cache adapter if a concrete use case justifies the extra API surface. The first step should be small and testable, not a Redis abstraction by default.
+  >
+  > Added two small, explicit cache controls to `VerifyAuthOptions`: `jwksCacheTtlMs` to override the default 5 minute per-process JWKS TTL and `skipJwksCache` to bypass the cache for a given verifier/middleware instance. Also exported `invalidateJwksCache(logtoUrl)` and `clearJwksCache()` from the backend entrypoint so operators and tests can force a refresh without restarting the process. Added focused verifier tests for custom TTL expiry, cache bypass, and explicit invalidation, and documented the new controls in both backend docs surfaces.
 
 - [x] **9.2 — Review and remove unnecessary reload behavior in `SignInPage`** Forced reloads should be eliminated or documented as an explicit contract.
 


### PR DESCRIPTION
## Summary
- add configurable JWKS cache controls to the backend verifier via jwksCacheTtlMs, skipJwksCache, invalidateJwksCache, and clearJwksCache
- add AuthProvider lifecycle callbacks: onTokenRefresh, onAuthError, and onSignOut with explicit event payload types
- update 	asks-v2.md to mark Phase 9.1 and 9.3 complete, including implementation notes

## Verification
- 
px vitest run src/backend/verify-auth.test.ts
- 
px vitest run src/context.test.tsx
- 
pm run build

## Notes
- kept the JWKS cache work intentionally small: TTL override, per-call cache bypass, and explicit invalidation helpers only
- avoided a generic auth event bus; the provider exposes only the scoped lifecycle hooks requested in the task