### PR TITLE
Improve SSR docs and add backend authorization helpers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -282,12 +282,111 @@ import { SignInButton } from '@ouim/simple-logto'
 ;<SignInButton />
 ```
 
+## SSR And Router Boundaries
+
+The frontend entrypoint is intentionally browser-oriented. `AuthProvider`, `useAuth`, `SignInPage`, `CallbackPage`, and `UserCenter` all rely on client-only behaviors such as cookies, `window`, popup messaging, focus events, or browser navigation.
+
+Use these rules when integrating into SSR-capable apps:
+
+- Render frontend auth components only from client components.
+- Keep `/signin` and `/callback` as real browser routes, not server-only handlers.
+- Expect the initial server render to be unauthenticated until the client hydrates and loads the Logto session.
+- Do not treat server-rendered auth state from the frontend package as authoritative for backend access control; use the backend verifier helpers for that.
+
+### React Router
+
+Wrap the router tree in `AuthProvider` and pass a router-aware `customNavigate` callback so auth redirects stay inside the SPA router.
+
+```tsx
+'use client'
+
+import { AuthProvider, CallbackPage, SignInPage } from '@ouim/simple-logto'
+import { BrowserRouter, Route, Routes, useNavigate } from 'react-router-dom'
+
+function AuthShell() {
+  const navigate = useNavigate()
+
+  return (
+    <AuthProvider
+      config={logtoConfig}
+      callbackUrl={`${window.location.origin}/callback`}
+      customNavigate={url => navigate(url)}
+      enablePopupSignIn
+    >
+      <Routes>
+        <Route path="/signin" element={<SignInPage />} />
+        <Route path="/callback" element={<CallbackPage />} />
+        <Route path="/" element={<Dashboard />} />
+      </Routes>
+    </AuthProvider>
+  )
+}
+
+export function App() {
+  return (
+    <BrowserRouter>
+      <AuthShell />
+    </BrowserRouter>
+  )
+}
+```
+
+### Next.js App Router
+
+Keep the auth UI behind client components and let the backend subpath handle server-side request verification.
+
+```tsx
+// app/providers.tsx
+'use client'
+
+import { AuthProvider } from '@ouim/simple-logto'
+import { useRouter } from 'next/navigation'
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const router = useRouter()
+
+  return (
+    <AuthProvider
+      config={logtoConfig}
+      callbackUrl={`${process.env.NEXT_PUBLIC_APP_URL}/callback`}
+      customNavigate={url => router.push(url)}
+    >
+      {children}
+    </AuthProvider>
+  )
+}
+```
+
+```tsx
+// app/signin/page.tsx
+'use client'
+
+import { SignInPage } from '@ouim/simple-logto'
+
+export default function SignIn() {
+  return <SignInPage />
+}
+```
+
+```tsx
+// app/callback/page.tsx
+'use client'
+
+import { CallbackPage } from '@ouim/simple-logto'
+
+export default function Callback() {
+  return <CallbackPage />
+}
+```
+
+For protected server routes, route handlers, or middleware, import from `@ouim/simple-logto/backend` instead of trying to read frontend auth state during SSR.
+
 ## Backend API
 
 Import backend helpers from the dedicated subpath:
 
 ```ts
-import { createExpressAuthMiddleware, verifyAuth, verifyNextAuth } from '@ouim/simple-logto/backend'
+import { createExpressAuthMiddleware, hasScopes, requireScopes, verifyAuth, verifyNextAuth } from '@ouim/simple-logto/backend'
 ```
 
 ### Express middleware
@@ -340,6 +439,28 @@ export async function GET(request: Request) {
 }
 ```
 
+### SSR-safe backend verification pattern
+
+For SSR frameworks, make authorization decisions on the server with the backend subpath and pass only the derived result to your rendered UI.
+
+```ts
+import { verifyAuth } from '@ouim/simple-logto/backend'
+
+export async function loadUserFromRequest(request: Request) {
+  const auth = await verifyAuth(request, {
+    logtoUrl: process.env.LOGTO_URL!,
+    audience: process.env.LOGTO_AUDIENCE!,
+    allowGuest: true,
+  })
+
+  return {
+    userId: auth.userId,
+    isAuthenticated: auth.isAuthenticated,
+    isGuest: auth.isGuest,
+  }
+}
+```
+
 ### Generic token verification
 
 ```ts
@@ -360,6 +481,40 @@ const auth = await verifyAuth('your-jwt-token', {
 - `allowGuest?`: enables guest auth fallback
 - `jwksCacheTtlMs?`: overrides the default 5 minute in-memory JWKS cache TTL
 - `skipJwksCache?`: bypasses the in-memory JWKS cache for a single verifier/middleware instance
+
+### Multi-scope and role authorization helpers
+
+If you need more than the built-in single `requiredScope` check, use the backend authorization helpers after token verification:
+
+```ts
+import { hasRole, hasScopes, requireRole, requireScopes, verifyAuth } from '@ouim/simple-logto/backend'
+
+const auth = await verifyAuth(request, {
+  logtoUrl: process.env.LOGTO_URL!,
+  audience: process.env.LOGTO_AUDIENCE!,
+})
+
+if (!hasScopes(auth, ['profile:read', 'profile:write'], { mode: 'any' })) {
+  return Response.json({ error: 'Forbidden' }, { status: 403 })
+}
+
+requireScopes(auth, ['profile:read', 'profile:write'])
+
+if (!hasRole(auth, 'admin')) {
+  return Response.json({ error: 'Forbidden' }, { status: 403 })
+}
+
+requireRole(auth, 'admin')
+```
+
+Notes:
+
+- `hasScopes(subject, scopes, { mode })` returns a boolean for either a raw `AuthPayload` or a full `AuthContext`.
+- `requireScopes(subject, scopes, { mode })` throws an error you can map to `403`.
+- `mode: 'all'` is the default; use `mode: 'any'` when any one of the scopes should be enough.
+- Scope parsing follows the OAuth `scope` claim convention: a whitespace-delimited string.
+- `hasRole(subject, role, { claimKeys })` and `requireRole(subject, role, { claimKeys })` check role claims without coupling the logic to Express or Next.js.
+- Role helpers look for `roles` first and then `role` by default. If your Logto tenant maps roles into a custom claim, pass `claimKeys`, for example `['https://example.com/roles']`.
 
 ### JWKS cache controls
 
@@ -452,6 +607,7 @@ import type {
 import type {
   AuthContext,
   AuthPayload,
+  AuthorizationMode,
   VerifyAuthOptions,
   ExpressRequest,
   ExpressResponse,

--- a/smoke-fixtures/node-backend/check.cjs
+++ b/smoke-fixtures/node-backend/check.cjs
@@ -1,4 +1,13 @@
-const { buildAuthCookieHeader, createExpressAuthMiddleware, verifyAuth, verifyNextAuth } = require('@ouim/simple-logto/backend')
+const {
+  buildAuthCookieHeader,
+  createExpressAuthMiddleware,
+  hasRole,
+  hasScopes,
+  requireRole,
+  requireScopes,
+  verifyAuth,
+  verifyNextAuth,
+} = require('@ouim/simple-logto/backend')
 
 const middleware = createExpressAuthMiddleware({
   logtoUrl: 'https://example.logto.app',
@@ -10,14 +19,41 @@ if (typeof middleware !== 'function') {
   throw new Error('Expected createExpressAuthMiddleware() to return a function.')
 }
 
-if (typeof verifyAuth !== 'function' || typeof verifyNextAuth !== 'function') {
+if (
+  typeof verifyAuth !== 'function' ||
+  typeof verifyNextAuth !== 'function' ||
+  typeof hasScopes !== 'function' ||
+  typeof requireScopes !== 'function' ||
+  typeof hasRole !== 'function' ||
+  typeof requireRole !== 'function'
+) {
   throw new Error('Expected backend helpers to be exported for CommonJS consumers.')
 }
 
 const cookieHeader = buildAuthCookieHeader('demo-token', { maxAge: 60 })
+const auth = {
+  userId: 'user-1',
+  isAuthenticated: true,
+  payload: {
+    sub: 'user-1',
+    scope: 'read:profile write:profile',
+    roles: ['admin'],
+  },
+}
 
 if (!cookieHeader.includes('HttpOnly')) {
   throw new Error('Expected buildAuthCookieHeader() to include HttpOnly.')
 }
+
+if (!hasScopes(auth, ['read:profile', 'write:profile'])) {
+  throw new Error('Expected hasScopes() to validate exported scope helpers.')
+}
+
+if (!hasRole(auth, 'admin')) {
+  throw new Error('Expected hasRole() to validate exported role helpers.')
+}
+
+requireScopes(auth, ['read:profile', 'write:profile'])
+requireRole(auth, 'admin')
 
 console.log('backend CommonJS smoke test passed')

--- a/smoke-fixtures/node-backend/check.mjs
+++ b/smoke-fixtures/node-backend/check.mjs
@@ -1,6 +1,10 @@
 import {
   buildAuthCookieHeader,
   createExpressAuthMiddleware,
+  hasRole,
+  hasScopes,
+  requireRole,
+  requireScopes,
   verifyAuth,
   verifyNextAuth,
 } from '@ouim/simple-logto/backend'
@@ -15,14 +19,41 @@ if (typeof middleware !== 'function') {
   throw new Error('Expected createExpressAuthMiddleware() to return a function.')
 }
 
-if (typeof verifyAuth !== 'function' || typeof verifyNextAuth !== 'function') {
+if (
+  typeof verifyAuth !== 'function' ||
+  typeof verifyNextAuth !== 'function' ||
+  typeof hasScopes !== 'function' ||
+  typeof requireScopes !== 'function' ||
+  typeof hasRole !== 'function' ||
+  typeof requireRole !== 'function'
+) {
   throw new Error('Expected backend helpers to be exported for ESM consumers.')
 }
 
 const cookieHeader = buildAuthCookieHeader('demo-token', { maxAge: 60 })
+const auth = {
+  userId: 'user-1',
+  isAuthenticated: true,
+  payload: {
+    sub: 'user-1',
+    scope: 'read:profile write:profile',
+    roles: ['admin'],
+  },
+}
 
 if (!cookieHeader.includes('SameSite=Strict')) {
   throw new Error('Expected buildAuthCookieHeader() to include SameSite=Strict.')
 }
+
+if (!hasScopes(auth, ['read:profile', 'write:profile'])) {
+  throw new Error('Expected hasScopes() to validate exported scope helpers.')
+}
+
+if (!hasRole(auth, 'admin')) {
+  throw new Error('Expected hasRole() to validate exported role helpers.')
+}
+
+requireScopes(auth, ['read:profile', 'write:profile'])
+requireRole(auth, 'admin')
 
 console.log('backend ESM smoke test passed')

--- a/smoke-fixtures/node-backend/src/index.ts
+++ b/smoke-fixtures/node-backend/src/index.ts
@@ -1,4 +1,4 @@
-import { createExpressAuthMiddleware } from '@ouim/simple-logto/backend'
+import { createExpressAuthMiddleware, hasRole, hasScopes, requireRole, requireScopes } from '@ouim/simple-logto/backend'
 import type { AuthContext, VerifyAuthOptions } from '@ouim/simple-logto/backend'
 
 const options: VerifyAuthOptions = {
@@ -13,10 +13,16 @@ const authContext: AuthContext = {
   payload: {
     sub: 'user-1',
     scope: 'openid profile',
+    roles: ['admin'],
   },
 }
 
 const middleware = createExpressAuthMiddleware(options)
+const canManageUsers = hasScopes(authContext, ['openid', 'profile'], { mode: 'all' }) && hasRole(authContext, 'admin')
+
+requireScopes(authContext, 'openid profile')
+requireRole(authContext, 'admin')
 
 void authContext
 void middleware
+void canManageUsers

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -22,6 +22,17 @@ npm install @ouim/simple-logto
 
 ## Usage
 
+## SSR And Runtime Boundary
+
+Use the backend subpath anywhere you need request-time authorization in SSR frameworks. This module is safe for Node.js server contexts and should be the source of truth for access control in:
+
+- Next.js route handlers
+- Next.js middleware
+- server-rendered loaders/actions
+- Express or custom Node servers
+
+Do not try to infer authoritative server auth state from the frontend package during SSR. The frontend entrypoint is browser-first and hydrates auth state on the client; the backend verifier should own request authentication on the server.
+
 ### Express.js Middleware
 
 `createExpressAuthMiddleware` automatically parses cookies for you so there's no need to install or `app.use` a separate `cookie-parser` middleware. Just import and mount the helper as shown below.
@@ -103,6 +114,10 @@ export const config = {
   matcher: '/api/protected/:path*',
 }
 ```
+
+### Pairing Next.js server checks with client auth UI
+
+Use `@ouim/simple-logto` only in client components such as `app/signin/page.tsx`, `app/callback/page.tsx`, or a client-side providers wrapper. Use `@ouim/simple-logto/backend` in route handlers and middleware. That split avoids hydration confusion and keeps browser-only logic out of the server bundle.
 
 ### Generic Usage
 

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -187,6 +187,31 @@ requireScopes(auth, ['read:reports', 'write:reports'])
 - `mode` defaults to `'all'`; set `'any'` to accept any matching scope
 - Both helpers accept either a raw `AuthPayload` or a full `AuthContext`
 
+## Role-based Authorization Helpers
+
+Use the exported role helpers when your access control is role-oriented instead of scope-oriented:
+
+```ts
+import { hasRole, requireRole, verifyAuth } from '@ouim/simple-logto/backend'
+
+const auth = await verifyAuth(request, {
+  logtoUrl: 'https://your-logto-domain.com',
+  audience: 'your-api-resource-identifier',
+})
+
+if (!hasRole(auth, 'admin')) {
+  throw new Error('Forbidden')
+}
+
+requireRole(auth, 'admin')
+```
+
+- `hasRole(subject, role, { claimKeys })` returns `true` / `false`
+- `requireRole(subject, role, { claimKeys })` throws a descriptive authorization error
+- Default role claim lookup is `roles`, then `role`
+- If your Logto tenant emits roles under a custom namespaced claim, pass `claimKeys` explicitly
+- The helpers accept either a raw `AuthPayload` or a full `AuthContext`
+
 ## JWKS Cache Controls
 
 The backend verifier keeps a per-process in-memory JWKS cache by default. That is usually the right tradeoff, but you can now control it explicitly when needed:

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -163,6 +163,30 @@ The verification helpers will look for the JWT token in the following order:
 - `jwksCacheTtlMs`: Override the per-process JWKS cache TTL in milliseconds (optional, defaults to 5 minutes)
 - `skipJwksCache`: Force a fresh JWKS fetch for this verification call instead of reading/writing the in-memory cache (optional)
 
+## Multi-scope Authorization Helpers
+
+`requiredScope` is intentionally narrow. When you need more than one scope, verify the token first and then use the exported helpers:
+
+```ts
+import { hasScopes, requireScopes, verifyAuth } from '@ouim/simple-logto/backend'
+
+const auth = await verifyAuth(request, {
+  logtoUrl: 'https://your-logto-domain.com',
+  audience: 'your-api-resource-identifier',
+})
+
+if (!hasScopes(auth, ['read:reports', 'write:reports'], { mode: 'any' })) {
+  throw new Error('Forbidden')
+}
+
+requireScopes(auth, ['read:reports', 'write:reports'])
+```
+
+- `hasScopes(subject, scopes, { mode })` returns `true` / `false`
+- `requireScopes(subject, scopes, { mode })` throws a descriptive authorization error
+- `mode` defaults to `'all'`; set `'any'` to accept any matching scope
+- Both helpers accept either a raw `AuthPayload` or a full `AuthContext`
+
 ## JWKS Cache Controls
 
 The backend verifier keeps a per-process in-memory JWKS cache by default. That is usually the right tradeoff, but you can now control it explicitly when needed:

--- a/src/backend/authorization.test.ts
+++ b/src/backend/authorization.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { hasScopes, requireScopes } from './authorization'
+import { hasRole, hasScopes, requireRole, requireScopes } from './authorization'
 import type { AuthContext, AuthPayload } from './types'
 
 function buildPayload(overrides: Partial<AuthPayload> = {}): AuthPayload {
@@ -63,5 +63,44 @@ describe('scope authorization helpers', () => {
   it('treats an empty required scope list as a no-op', () => {
     expect(() => requireScopes(buildPayload(), [])).not.toThrow()
     expect(hasScopes(buildPayload(), [])).toBe(true)
+  })
+})
+
+describe('role authorization helpers', () => {
+  it('returns true when the payload contains the requested role in roles[]', () => {
+    const payload = buildPayload({ roles: ['admin', 'support'] })
+    expect(hasRole(payload, 'admin')).toBe(true)
+  })
+
+  it('falls back to the role claim when roles is not present', () => {
+    const payload = buildPayload({ role: 'admin support' })
+    expect(hasRole(payload, 'support')).toBe(true)
+  })
+
+  it('supports custom claim keys', () => {
+    const payload = buildPayload({ 'https://example.com/roles': ['tenant:owner'] })
+    expect(hasRole(payload, 'tenant:owner', { claimKeys: ['https://example.com/roles'] })).toBe(true)
+  })
+
+  it('returns false when the requested role is missing', () => {
+    const payload = buildPayload({ roles: ['viewer'] })
+    expect(hasRole(payload, 'admin')).toBe(false)
+  })
+
+  it('returns false when no role claims are present', () => {
+    expect(hasRole(buildPayload(), 'admin')).toBe(false)
+  })
+
+  it('accepts an AuthContext as the subject', () => {
+    const auth = buildAuthContext(buildPayload({ roles: ['admin'] }))
+    expect(hasRole(auth, 'admin')).toBe(true)
+  })
+
+  it('requireRole does not throw when the role is present', () => {
+    expect(() => requireRole(buildPayload({ roles: ['admin'] }), 'admin')).not.toThrow()
+  })
+
+  it('requireRole throws a descriptive error when the role is missing', () => {
+    expect(() => requireRole(buildPayload({ roles: ['viewer'] }), 'admin')).toThrow(/Missing required role/)
   })
 })

--- a/src/backend/authorization.test.ts
+++ b/src/backend/authorization.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { hasScopes, requireScopes } from './authorization'
+import type { AuthContext, AuthPayload } from './types'
+
+function buildPayload(overrides: Partial<AuthPayload> = {}): AuthPayload {
+  return {
+    sub: 'user-123',
+    scope: 'read:profile write:profile admin:users',
+    iss: 'https://tenant.logto.app/oidc',
+    ...overrides,
+  }
+}
+
+function buildAuthContext(payload: AuthPayload | null): AuthContext {
+  return {
+    userId: payload?.sub ?? null,
+    isAuthenticated: Boolean(payload),
+    payload,
+    isGuest: false,
+  }
+}
+
+describe('scope authorization helpers', () => {
+  it('returns true when all required scopes are present by default', () => {
+    expect(hasScopes(buildPayload(), ['read:profile', 'write:profile'])).toBe(true)
+  })
+
+  it('returns false when one of the required scopes is missing in all mode', () => {
+    expect(hasScopes(buildPayload(), ['read:profile', 'billing:read'])).toBe(false)
+  })
+
+  it('supports any mode for partial scope matches', () => {
+    expect(hasScopes(buildPayload(), ['billing:read', 'admin:users'], { mode: 'any' })).toBe(true)
+  })
+
+  it('accepts an AuthContext as the subject', () => {
+    const auth = buildAuthContext(buildPayload())
+    expect(hasScopes(auth, 'admin:users')).toBe(true)
+  })
+
+  it('splits whitespace-delimited required scope strings', () => {
+    expect(hasScopes(buildPayload(), 'read:profile write:profile')).toBe(true)
+  })
+
+  it('returns false when the payload is missing', () => {
+    expect(hasScopes(buildAuthContext(null), 'read:profile')).toBe(false)
+  })
+
+  it('requireScopes does not throw when all scopes are present', () => {
+    expect(() => requireScopes(buildPayload(), ['read:profile', 'admin:users'])).not.toThrow()
+  })
+
+  it('requireScopes supports any mode', () => {
+    expect(() => requireScopes(buildPayload(), ['billing:read', 'admin:users'], { mode: 'any' })).not.toThrow()
+  })
+
+  it('requireScopes throws a descriptive error when scopes are missing', () => {
+    expect(() => requireScopes(buildPayload(), ['read:profile', 'billing:read'])).toThrow(
+      /Missing required scopes/,
+    )
+  })
+
+  it('treats an empty required scope list as a no-op', () => {
+    expect(() => requireScopes(buildPayload(), [])).not.toThrow()
+    expect(hasScopes(buildPayload(), [])).toBe(true)
+  })
+})

--- a/src/backend/authorization.ts
+++ b/src/backend/authorization.ts
@@ -6,7 +6,12 @@ export interface ScopeCheckOptions {
   mode?: AuthorizationMode
 }
 
+export interface RoleCheckOptions {
+  claimKeys?: string[]
+}
+
 type AuthSubject = AuthContext | AuthPayload | null | undefined
+const DEFAULT_ROLE_CLAIM_KEYS = ['roles', 'role']
 
 function isAuthContext(subject: AuthSubject): subject is AuthContext {
   return typeof subject === 'object' && subject !== null && 'isAuthenticated' in subject
@@ -24,10 +29,34 @@ function normalizeScopeInput(scopes: string | string[]): string[] {
     .filter(Boolean)
 }
 
+function normalizeRoleInput(roles: string | string[]): string[] {
+  return (Array.isArray(roles) ? roles : [roles])
+    .flatMap(role => role.split(/[,\s]+/))
+    .map(role => role.trim())
+    .filter(Boolean)
+}
+
 function readTokenScopes(subject: AuthSubject): string[] {
   const payload = getPayload(subject)
   if (!payload?.scope) return []
   return normalizeScopeInput(payload.scope)
+}
+
+function readTokenRoles(subject: AuthSubject, claimKeys: string[]): string[] {
+  const payload = getPayload(subject)
+  if (!payload) return []
+
+  for (const claimKey of claimKeys) {
+    const claimValue = payload[claimKey]
+    if (Array.isArray(claimValue) && claimValue.every(role => typeof role === 'string')) {
+      return normalizeRoleInput(claimValue)
+    }
+    if (typeof claimValue === 'string') {
+      return normalizeRoleInput(claimValue)
+    }
+  }
+
+  return []
 }
 
 /**
@@ -76,5 +105,50 @@ export function requireScopes(subject: AuthSubject, scopes: string | string[], o
   const expectation = mode === 'any' ? 'at least one of' : 'all of'
   throw new Error(
     `Missing required scopes (${expectation}: ${requiredScopes.join(', ')}). Token scopes: ${grantedScopes.join(', ') || '(none)'}. Missing: ${missingScopes.join(', ') || requiredScopes.join(', ')}`,
+  )
+}
+
+/**
+ * Return `true` when the token payload contains the requested role.
+ *
+ * By default the helper checks `roles` first and then `role`. Override
+ * `claimKeys` when your tenant emits roles under a custom claim name.
+ *
+ * @example
+ * hasRole(auth, 'admin')
+ * hasRole(auth.payload, 'support', { claimKeys: ['https://example.com/roles'] })
+ */
+export function hasRole(subject: AuthSubject, role: string, options: RoleCheckOptions = {}): boolean {
+  const requiredRoles = normalizeRoleInput(role)
+  if (requiredRoles.length === 0) return true
+
+  const claimKeys = options.claimKeys?.length ? options.claimKeys : DEFAULT_ROLE_CLAIM_KEYS
+  const grantedRoles = readTokenRoles(subject, claimKeys)
+  return requiredRoles.every(requiredRole => grantedRoles.includes(requiredRole))
+}
+
+/**
+ * Assert that the token payload contains the requested role.
+ *
+ * Throws a descriptive error when the role claim is missing or does not contain
+ * the required role.
+ *
+ * @example
+ * requireRole(auth, 'admin')
+ * requireRole(payload, 'tenant:owner', { claimKeys: ['https://example.com/roles'] })
+ */
+export function requireRole(subject: AuthSubject, role: string, options: RoleCheckOptions = {}): void {
+  const requiredRoles = normalizeRoleInput(role)
+  if (requiredRoles.length === 0) return
+
+  const claimKeys = options.claimKeys?.length ? options.claimKeys : DEFAULT_ROLE_CLAIM_KEYS
+  const grantedRoles = readTokenRoles(subject, claimKeys)
+
+  if (requiredRoles.every(requiredRole => grantedRoles.includes(requiredRole))) {
+    return
+  }
+
+  throw new Error(
+    `Missing required role: ${requiredRoles.join(', ')}. Checked claims: ${claimKeys.join(', ')}. Token roles: ${grantedRoles.join(', ') || '(none)'}`,
   )
 }

--- a/src/backend/authorization.ts
+++ b/src/backend/authorization.ts
@@ -1,0 +1,80 @@
+import type { AuthContext, AuthPayload } from './types.js'
+
+export type AuthorizationMode = 'all' | 'any'
+
+export interface ScopeCheckOptions {
+  mode?: AuthorizationMode
+}
+
+type AuthSubject = AuthContext | AuthPayload | null | undefined
+
+function isAuthContext(subject: AuthSubject): subject is AuthContext {
+  return typeof subject === 'object' && subject !== null && 'isAuthenticated' in subject
+}
+
+function getPayload(subject: AuthSubject): AuthPayload | null {
+  if (!subject) return null
+  return isAuthContext(subject) ? subject.payload : subject
+}
+
+function normalizeScopeInput(scopes: string | string[]): string[] {
+  return (Array.isArray(scopes) ? scopes : [scopes])
+    .flatMap(scope => scope.split(/\s+/))
+    .map(scope => scope.trim())
+    .filter(Boolean)
+}
+
+function readTokenScopes(subject: AuthSubject): string[] {
+  const payload = getPayload(subject)
+  if (!payload?.scope) return []
+  return normalizeScopeInput(payload.scope)
+}
+
+/**
+ * Return `true` when the token payload contains the requested scopes.
+ *
+ * Accepts either a raw `AuthPayload` or a full `AuthContext`. Scope comparison is
+ * whitespace-delimited to match the standard OAuth `scope` claim shape used by Logto.
+ *
+ * @example
+ * hasScopes(auth.payload, ['read:profile', 'write:profile'])
+ * hasScopes(auth, ['read:profile', 'write:profile'], { mode: 'any' })
+ */
+export function hasScopes(subject: AuthSubject, scopes: string | string[], options: ScopeCheckOptions = {}): boolean {
+  const requiredScopes = normalizeScopeInput(scopes)
+  if (requiredScopes.length === 0) return true
+
+  const grantedScopes = readTokenScopes(subject)
+  const { mode = 'all' } = options
+
+  return mode === 'any'
+    ? requiredScopes.some(scope => grantedScopes.includes(scope))
+    : requiredScopes.every(scope => grantedScopes.includes(scope))
+}
+
+/**
+ * Assert that the token payload contains the requested scopes.
+ *
+ * Throws a descriptive error listing the missing scopes when the check fails.
+ *
+ * @example
+ * requireScopes(auth, ['read:profile', 'write:profile'])
+ * requireScopes(payload, ['admin:read', 'admin:write'], { mode: 'any' })
+ */
+export function requireScopes(subject: AuthSubject, scopes: string | string[], options: ScopeCheckOptions = {}): void {
+  const requiredScopes = normalizeScopeInput(scopes)
+  if (requiredScopes.length === 0) return
+
+  const grantedScopes = readTokenScopes(subject)
+  const { mode = 'all' } = options
+
+  if (hasScopes(subject, requiredScopes, { mode })) {
+    return
+  }
+
+  const missingScopes = requiredScopes.filter(scope => !grantedScopes.includes(scope))
+  const expectation = mode === 'any' ? 'at least one of' : 'all of'
+  throw new Error(
+    `Missing required scopes (${expectation}: ${requiredScopes.join(', ')}). Token scopes: ${grantedScopes.join(', ') || '(none)'}. Missing: ${missingScopes.join(', ') || requiredScopes.join(', ')}`,
+  )
+}

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1,3 +1,4 @@
 export * from './verify-auth.js';
 export * from './csrf.js';
+export * from './authorization.js';
 export * from './types.js';

--- a/tasks-v2.md
+++ b/tasks-v2.md
@@ -325,9 +325,11 @@
   >
   > Added `onTokenRefresh`, `onAuthError`, and `onSignOut` to `AuthProviderProps` with explicit event payload types in `src/types.ts` instead of a generic emitter. `onTokenRefresh` only fires when an already-loaded authenticated session receives a different access token; `onAuthError` reports both transient and definitive auth failures with a `willSignOut` flag; and `onSignOut` fires immediately before the provider initiates local or global sign-out, including the reason (`user`, `auth_error`, `missing_access_token`, `transient_error_limit`). Added focused context tests for refresh and sign-out/error flows and documented the callbacks in the public README.
 
-- [ ] **9.4 — Improve SSR/client boundary documentation and helpers** The package uses client-only guards in several places; consumers need clearer guidance.
+- [x] **9.4 — Improve SSR/client boundary documentation and helpers** The package uses client-only guards in several places; consumers need clearer guidance.
 
   > Document supported SSR patterns, hydration expectations, and router integration examples for React Router and Next.js. Add small helper docs or examples before adding more runtime abstraction.
+  >
+  > Added an explicit `SSR And Router Boundaries` section to the main `README.md` describing the client-only surface (`AuthProvider`, `useAuth`, `SignInPage`, `CallbackPage`, `UserCenter`), hydration expectations, and the rule that backend authorization must come from `@ouim/simple-logto/backend` during SSR. Also added concrete React Router and Next.js App Router examples, plus matching backend-side guidance in `src/backend/README.md` so the frontend/server split is documented in both docs entrypoints.
 
 - [ ] **9.5 — Add bundle-size monitoring in CI** This package ships UI and auth helpers; size regressions should be visible.
 

--- a/tasks-v2.md
+++ b/tasks-v2.md
@@ -359,6 +359,10 @@
 
   > Consider a narrow `usePermission` hook only after the exact token/claim source is clear and stable in the frontend auth state.
 
+- [ ] **10.4 — Add executable SSR integration fixtures for documented auth flows** The new SSR/router guidance is still documentation-only and could drift over time.
+
+  > Add minimal fixture coverage for the documented React Router and/or Next.js SSR integration patterns so the examples are validated by CI instead of relying only on README maintenance.
+
 ---
 
 ## Phase 11 — Ecosystem & Community Polish

--- a/tasks-v2.md
+++ b/tasks-v2.md
@@ -349,9 +349,11 @@
   >
   > Added framework-agnostic backend helpers in `src/backend/authorization.ts`: `hasScopes(subject, scopes, { mode })` for boolean checks and `requireScopes(subject, scopes, { mode })` for assertion-style guards. Both accept either a raw `AuthPayload` or a full `AuthContext`, normalize OAuth-style whitespace-delimited scope strings, and support `'all'` / `'any'` matching without changing existing middleware behavior. Exported them from the backend entrypoint, added focused unit coverage in `src/backend/authorization.test.ts`, and documented the pattern in both README surfaces.
 
-- [ ] **10.2 — Add role-based access control (RBAC) helpers** Roles are a common follow-on need once token verification is stable.
+- [x] **10.2 — Add role-based access control (RBAC) helpers** Roles are a common follow-on need once token verification is stable.
 
   > Add helpers like `hasRole` / `requireRole` against Logto role claims, with explicit docs about expected claim shape and tenant configuration assumptions.
+  >
+  > Extended `src/backend/authorization.ts` with `hasRole(subject, role, { claimKeys })` and `requireRole(subject, role, { claimKeys })`, keeping the API framework-agnostic and aligned with the scope helpers from 10.1. The helpers accept `AuthPayload` or `AuthContext`, read `roles` first and `role` second by default, and allow custom claim names for tenants that map roles into namespaced claims. Added focused unit tests for array claims, string claims, custom claim keys, and error cases, and documented the default claim-shape assumptions plus the custom-claim override path in both backend docs surfaces.
 
 - [ ] **10.3 — Add a frontend permission helper** Conditional rendering against auth state should not require every consumer to re-parse permission data manually.
 

--- a/tasks-v2.md
+++ b/tasks-v2.md
@@ -343,9 +343,11 @@
 
 **Priority: 🟢 Low**
 
-- [ ] **10.1 — Add multi-scope authorization helpers** The current API only supports a single `requiredScope`.
+- [x] **10.1 — Add multi-scope authorization helpers** The current API only supports a single `requiredScope`.
 
   > Provide helpers such as `requireScopes(scopes, { mode: 'all' | 'any' })` without coupling them too tightly to Express or Next-specific middleware.
+  >
+  > Added framework-agnostic backend helpers in `src/backend/authorization.ts`: `hasScopes(subject, scopes, { mode })` for boolean checks and `requireScopes(subject, scopes, { mode })` for assertion-style guards. Both accept either a raw `AuthPayload` or a full `AuthContext`, normalize OAuth-style whitespace-delimited scope strings, and support `'all'` / `'any'` matching without changing existing middleware behavior. Exported them from the backend entrypoint, added focused unit coverage in `src/backend/authorization.test.ts`, and documented the pattern in both README surfaces.
 
 - [ ] **10.2 — Add role-based access control (RBAC) helpers** Roles are a common follow-on need once token verification is stable.
 


### PR DESCRIPTION
## Summary
- clarify SSR/client boundaries and router integration guidance in the root and backend docs
- add backend multi-scope authorization helpers: hasScopes and equireScopes
- add backend role authorization helpers: hasRole and equireRole
- mark tasks 9.4, 10.1, and 10.2 complete in 	asks-v2.md

## Verification
- 
px vitest run src/backend/authorization.test.ts
- 
px tsc --project tsconfig.build.json --noEmit
