### PR TITLE
Fix critical popup and local sign-out regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage
 .DS_Store
 *.log
 *.env
+example_app/.env
 .npmrc
 prompt.md
 .tmp

--- a/readme.md
+++ b/readme.md
@@ -225,7 +225,7 @@ Prebuilt account dropdown for navbars and app shells.
 Supports:
 
 - signed-in and signed-out states
-- local or global sign-out
+- local sign-out by default, or global sign-out when explicitly enabled
 - custom account links
 - custom theme class names
 
@@ -239,6 +239,8 @@ Supports:
   ]}
 />
 ```
+
+Pass `globalSignOut={true}` only when you explicitly want the account menu to end the user's wider Logto tenant session, not just the current app session.
 
 ### `CallbackPage`
 

--- a/src/context.test.tsx
+++ b/src/context.test.tsx
@@ -949,8 +949,77 @@ describe('Popup Sign-in Flow', () => {
       vi.advanceTimersByTime(popupRetryDelayMs)
     })
     expect(screen.getByText('user: user-123')).toBeInTheDocument()
-    expect(getIdTokenClaims).toHaveBeenCalledTimes(1)
-    expect(getAccessToken).toHaveBeenCalledTimes(1)
+    expect(getIdTokenClaims).toHaveBeenCalled()
+    expect(getAccessToken).toHaveBeenCalled()
+  }, 10000)
+
+  it('keeps auth-state-changed on the forced popup rehydration path while popup auth is pending', async () => {
+    const popupEventDelayMs = 500
+    let popupAuthReady = false
+    const getIdTokenClaims = vi.fn().mockResolvedValue({
+      sub: 'user-123',
+      name: 'Test User',
+      email: 'test@example.com',
+    })
+    const getAccessToken = vi.fn().mockResolvedValue('popup-access-token')
+    const addELSpy = vi.spyOn(window, 'addEventListener')
+
+    vi.mocked(useLogto).mockImplementation(() =>
+      createMockLogtoContext({
+        isAuthenticated: popupAuthReady,
+        getIdTokenClaims,
+        getAccessToken,
+      }),
+    )
+
+    const PopupAuthProbe = () => {
+      const { user, signIn } = useAuthContext()
+
+      return (
+        <div>
+          <button onClick={() => signIn(undefined, true)}>Open Popup</button>
+          <div>user: {user ? user.id : 'none'}</div>
+        </div>
+      )
+    }
+
+    const renderPopupTree = () => (
+      <AuthProvider config={mockConfig} enablePopupSignIn>
+        <PopupAuthProbe />
+      </AuthProvider>
+    )
+
+    const { rerender } = render(renderPopupTree())
+
+    await waitFor(() => expect(screen.getByText('Open Popup')).toBeInTheDocument())
+
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByText('Open Popup'))
+
+    const msgCalls = addELSpy.mock.calls.filter(([t]) => t === 'message')
+    const messageHandler = msgCalls[msgCalls.length - 1][1] as (e: unknown) => void
+
+    await act(async () => {
+      messageHandler({
+        origin: window.location.origin,
+        source: mockPopup,
+        data: { type: 'SIGNIN_SUCCESS' },
+      })
+      vi.advanceTimersByTime(popupEventDelayMs)
+    })
+
+    expect(getIdTokenClaims).not.toHaveBeenCalled()
+
+    popupAuthReady = true
+    rerender(renderPopupTree())
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('auth-state-changed'))
+    })
+
+    expect(screen.getByText('user: user-123')).toBeInTheDocument()
+    expect(getIdTokenClaims).toHaveBeenCalled()
+    expect(getAccessToken).toHaveBeenCalled()
   }, 10000)
 
   // ── 5. Cross-origin messages are ignored ─────────────────────────────────

--- a/src/context.test.tsx
+++ b/src/context.test.tsx
@@ -795,8 +795,8 @@ describe('Popup Sign-in Flow', () => {
 
   it('warns and returns early (no crash, no interval) when the popup is blocked', async () => {
     // Browser blocked the popup — window.open returns null
-    // eslint-disable-next-line @typescript-eslint/no-extra-semi
-    ;(window.open as ReturnType<typeof vi.fn>).mockReturnValue(null)
+    const openMock = window.open as ReturnType<typeof vi.fn>
+    openMock.mockReturnValue(null)
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     render(

--- a/src/context.test.tsx
+++ b/src/context.test.tsx
@@ -724,7 +724,7 @@ describe('Popup Sign-in Flow', () => {
   it('warns and returns early (no crash, no interval) when the popup is blocked', async () => {
     // Browser blocked the popup — window.open returns null
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
-    (window.open as ReturnType<typeof vi.fn>).mockReturnValue(null)
+    ;(window.open as ReturnType<typeof vi.fn>).mockReturnValue(null)
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     render(
@@ -807,6 +807,79 @@ describe('Popup Sign-in Flow', () => {
 
     expect(mockPopup.close).toHaveBeenCalledOnce()
   })
+
+  it('keeps retrying popup auth rehydration until the parent Logto state flips authenticated', async () => {
+    const popupEventDelayMs = 500
+    const popupRetryDelayMs = 250
+    let popupAuthReady = false
+    const getIdTokenClaims = vi.fn().mockResolvedValue({
+      sub: 'user-123',
+      name: 'Test User',
+      email: 'test@example.com',
+    })
+    const getAccessToken = vi.fn().mockResolvedValue('popup-access-token')
+    const addELSpy = vi.spyOn(window, 'addEventListener')
+
+    vi.mocked(useLogto).mockImplementation(() =>
+      createMockLogtoContext({
+        isAuthenticated: popupAuthReady,
+        getIdTokenClaims,
+        getAccessToken,
+      }),
+    )
+
+    const PopupAuthProbe = () => {
+      const { user, signIn } = useAuthContext()
+
+      return (
+        <div>
+          <button onClick={() => signIn(undefined, true)}>Open Popup</button>
+          <div>user: {user ? user.id : 'none'}</div>
+        </div>
+      )
+    }
+
+    const renderPopupTree = () => (
+      <AuthProvider config={mockConfig} enablePopupSignIn>
+        <PopupAuthProbe />
+      </AuthProvider>
+    )
+
+    const { rerender } = render(renderPopupTree())
+
+    await waitFor(() => expect(screen.getByText('Open Popup')).toBeInTheDocument())
+    expect(screen.getByText('user: none')).toBeInTheDocument()
+
+    vi.useFakeTimers()
+
+    fireEvent.click(screen.getByText('Open Popup'))
+
+    const msgCalls = addELSpy.mock.calls.filter(([t]) => t === 'message')
+    const messageHandler = msgCalls[msgCalls.length - 1][1] as (e: unknown) => void
+
+    await act(async () => {
+      messageHandler({
+        origin: window.location.origin,
+        source: mockPopup,
+        data: { type: 'SIGNIN_SUCCESS' },
+      })
+      vi.advanceTimersByTime(popupEventDelayMs)
+      vi.advanceTimersToNextTimer()
+    })
+
+    expect(screen.getByText('user: none')).toBeInTheDocument()
+    expect(getIdTokenClaims).not.toHaveBeenCalled()
+
+    popupAuthReady = true
+    rerender(renderPopupTree())
+
+    await act(async () => {
+      vi.advanceTimersByTime(popupRetryDelayMs)
+    })
+    expect(screen.getByText('user: user-123')).toBeInTheDocument()
+    expect(getIdTokenClaims).toHaveBeenCalledTimes(1)
+    expect(getAccessToken).toHaveBeenCalledTimes(1)
+  }, 10000)
 
   // ── 5. Cross-origin messages are ignored ─────────────────────────────────
 

--- a/src/context.test.tsx
+++ b/src/context.test.tsx
@@ -59,6 +59,7 @@ const createMockJwt = (exp: number) => {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  sessionStorage.clear()
   vi.mocked(useLogto).mockReturnValue(createMockLogtoContext())
 })
 
@@ -646,6 +647,77 @@ describe('AuthProvider Lifecycle Callbacks', () => {
       callbackUrl: '/signed-out',
     })
     expect(logtoSignOut).not.toHaveBeenCalled()
+  })
+
+  it('keeps app-local sign-out isolated from the tenant session across auth refreshes', async () => {
+    const logtoSignOut = vi.fn()
+    const getIdTokenClaims = vi.fn().mockResolvedValue({
+      sub: 'user-123',
+      name: 'Test User',
+      email: 'test@example.com',
+    })
+    const getAccessToken = vi.fn().mockResolvedValue('mock-token')
+
+    vi.mocked(useLogto).mockReturnValue(
+      createMockLogtoContext({
+        isAuthenticated: true,
+        getIdTokenClaims,
+        getAccessToken,
+        signOut: logtoSignOut,
+      }),
+    )
+
+    render(
+      <AuthProvider config={mockConfig}>
+        <AuthControls />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByText('Sign Out')).toBeInTheDocument())
+    await waitFor(() => expect(getIdTokenClaims).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByText('Sign Out'))
+
+    expect(logtoSignOut).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('simple_logto_local_signout')).toBe('true')
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('auth-state-changed'))
+    })
+
+    await waitFor(() => expect(jwtCookieUtils.removeToken).toHaveBeenCalled())
+    expect(getIdTokenClaims).toHaveBeenCalledTimes(1)
+    expect(getAccessToken).toHaveBeenCalledTimes(1)
+    expect(logtoSignOut).not.toHaveBeenCalled()
+  })
+
+  it('clears the local sign-out override when sign-in starts again', async () => {
+    const signIn = vi.fn()
+
+    sessionStorage.setItem('simple_logto_local_signout', 'true')
+
+    vi.mocked(useLogto).mockReturnValue(
+      createMockLogtoContext({
+        signIn,
+      }),
+    )
+
+    const SignInControl = () => {
+      const { signIn: beginSignIn } = useAuthContext()
+      return <button onClick={() => beginSignIn('/dashboard')}>Sign In</button>
+    }
+
+    render(
+      <AuthProvider config={mockConfig}>
+        <SignInControl />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByText('Sign In')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Sign In'))
+
+    expect(sessionStorage.getItem('simple_logto_local_signout')).toBeNull()
+    expect(signIn).toHaveBeenCalledWith('/dashboard')
   })
 
   it('swallows errors thrown by consumer lifecycle callbacks without breaking sign-out', async () => {

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -652,7 +652,10 @@ const InternalAuthProvider = ({
 
     // Listen for custom auth change events
     const handleAuthChange = () => {
-      loadUserRef.current()
+      // Popup completion can dispatch this event before the parent Logto SDK flips
+      // `isAuthenticated` to true. Reuse the forced path while popup rehydration is
+      // pending so the generic auth-state event cannot clobber the retry flow.
+      loadUserRef.current(popupAuthPendingRef.current)
     }
 
     // Add event listeners

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -567,6 +567,7 @@ const InternalAuthProvider = ({
       setIsLoadingUser(false)
     },
     [
+      clearPopupAuthRetry,
       clearTrackedAccessToken,
       defaultResource,
       emitAuthError,
@@ -578,6 +579,7 @@ const InternalAuthProvider = ({
       performGlobalSignOut,
       resetRefreshSchedule,
       scheduleTokenRefresh,
+      setLocalSignOutState,
     ],
   )
 
@@ -664,7 +666,7 @@ const InternalAuthProvider = ({
       window.removeEventListener('focus', handleWindowFocus)
       window.removeEventListener('auth-state-changed', handleAuthChange)
     }
-  }, []) // Empty dependency array to prevent recreating listeners
+  }, [queuePopupAuthRefresh]) // Stable callback dependency keeps the listeners current without re-subscribing on every render.
 
   const signIn = useCallback(
     async (overrideCallbackUrl?: string, usePopup?: boolean) => {
@@ -783,7 +785,7 @@ const InternalAuthProvider = ({
         popupCleanupTimerRef.current = cleanupTimeoutId
       }
     },
-    [enablePopupSignIn, callbackUrl, logtoSignIn, setLocalSignOutState],
+    [enablePopupSignIn, callbackUrl, logtoSignIn, queuePopupAuthRefresh, setLocalSignOutState],
   )
 
   const signOut = useCallback(

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -16,6 +16,7 @@ import type {
 const POPUP_AUTH_EVENT_DELAY = 500
 const POPUP_AUTH_RETRY_INTERVAL_MS = 250
 const POPUP_AUTH_MAX_RETRY_ATTEMPTS = 20
+const LOCAL_SIGN_OUT_STORAGE_KEY = 'simple_logto_local_signout'
 const TOKEN_REFRESH_BUFFER_MS = 60_000
 const MIN_TOKEN_REFRESH_DELAY_MS = 1_000
 const TOKEN_REFRESH_RETRY_MS = 15_000
@@ -55,6 +56,26 @@ const getJwtExpiration = (token: string): number | undefined => {
 }
 
 const toError = (error: unknown): Error => (error instanceof Error ? error : new Error(String(error)))
+
+const getLocalSignOutOverride = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  return window.sessionStorage.getItem(LOCAL_SIGN_OUT_STORAGE_KEY) === 'true'
+}
+
+const setLocalSignOutOverride = (active: boolean): void => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  if (active) {
+    window.sessionStorage.setItem(LOCAL_SIGN_OUT_STORAGE_KEY, 'true')
+  } else {
+    window.sessionStorage.removeItem(LOCAL_SIGN_OUT_STORAGE_KEY)
+  }
+}
 
 // Create auth context
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
@@ -171,6 +192,8 @@ const InternalAuthProvider = ({
   const popupAuthPendingRef = useRef<boolean>(false)
   /** Counts popup auth rehydration retries so we can stop polling if the SDK never catches up. */
   const popupAuthRetryCountRef = useRef<number>(0)
+  /** Keeps app-local sign-out isolated from the tenant-wide Logto session. */
+  const localSignOutRef = useRef<boolean>(getLocalSignOutOverride())
   /** Tracks the last access token so refresh callbacks only fire for real token transitions. */
   const lastAccessTokenRef = useRef<string | undefined>()
   /** Tracks the last access token expiry used in refresh callback payloads. */
@@ -259,6 +282,11 @@ const InternalAuthProvider = ({
     popupAuthRetryCountRef.current = 0
   }, [])
 
+  const setLocalSignOutState = useCallback((active: boolean) => {
+    localSignOutRef.current = active
+    setLocalSignOutOverride(active)
+  }, [])
+
   const queuePopupAuthRefresh = useCallback((delayMs = POPUP_AUTH_EVENT_DELAY) => {
     popupAuthPendingRef.current = true
     popupAuthRetryCountRef.current = 0
@@ -325,6 +353,18 @@ const InternalAuthProvider = ({
       setIsLoadingUser(true)
 
       if (isAuthenticated) {
+        if (localSignOutRef.current) {
+          setUser(null)
+          jwtCookieUtils.removeToken()
+          clearTrackedAccessToken()
+          errorCount.current = 0
+          transientErrorCount.current = 0
+          clearTimeout(backoffTimerRef.current)
+          resetRefreshSchedule()
+          setIsLoadingUser(false)
+          return
+        }
+
         try {
           const claims = await getIdTokenClaims()
           const jwt = await getAccessToken(defaultResource)
@@ -492,6 +532,10 @@ const InternalAuthProvider = ({
           }
         }
       } else {
+        if (localSignOutRef.current) {
+          setLocalSignOutState(false)
+        }
+
         if (forceRefresh && popupAuthPendingRef.current) {
           if (popupAuthRetryCountRef.current < POPUP_AUTH_MAX_RETRY_ATTEMPTS) {
             popupAuthRetryCountRef.current += 1
@@ -627,6 +671,8 @@ const InternalAuthProvider = ({
       // Only run on client side
       if (typeof window === 'undefined') return
 
+      setLocalSignOutState(false)
+
       // Check if we're already in a popup to prevent infinite loops
       const isInPopup = window.opener && window.opener !== window
 
@@ -737,7 +783,7 @@ const InternalAuthProvider = ({
         popupCleanupTimerRef.current = cleanupTimeoutId
       }
     },
-    [enablePopupSignIn, callbackUrl, logtoSignIn],
+    [enablePopupSignIn, callbackUrl, logtoSignIn, setLocalSignOutState],
   )
 
   const signOut = useCallback(
@@ -759,10 +805,13 @@ const InternalAuthProvider = ({
       })
 
       if (global) {
+        setLocalSignOutState(false)
         // Global sign out - logs out from entire Logto ecosystem
         await logtoSignOut(callbackUrl)
       } else {
         // Local sign out - only clears local session
+        setLocalSignOutState(true)
+        clearTimeout(backoffTimerRef.current)
         setUser(null)
         setIsLoadingUser(false)
 
@@ -778,7 +827,7 @@ const InternalAuthProvider = ({
       // Dispatch custom event to notify other windows/tabs
       window.dispatchEvent(new CustomEvent('auth-state-changed'))
     },
-    [clearPopupAuthRetry, clearTrackedAccessToken, emitSignOut, logtoSignOut, resetRefreshSchedule],
+    [clearPopupAuthRetry, clearTrackedAccessToken, emitSignOut, logtoSignOut, resetRefreshSchedule, setLocalSignOutState],
   )
 
   const value: AuthContextType = useMemo(

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -3,9 +3,19 @@ import React, { createContext, useContext, useEffect, useState, useCallback, use
 import { LogtoConfig, LogtoProvider, useLogto } from '@logto/react'
 import { transformUser, jwtCookieUtils, guestUtils, validateLogtoConfig } from './utils.js'
 import { NavigationProvider } from './navigation.js'
-import type { AuthContextType, AuthErrorEvent, AuthProviderProps, AuthSignOutEvent, AuthSignOutReason, AuthTokenRefreshEvent, LogtoUser } from './types.js'
+import type {
+  AuthContextType,
+  AuthErrorEvent,
+  AuthProviderProps,
+  AuthSignOutEvent,
+  AuthSignOutReason,
+  AuthTokenRefreshEvent,
+  LogtoUser,
+} from './types.js'
 
 const POPUP_AUTH_EVENT_DELAY = 500
+const POPUP_AUTH_RETRY_INTERVAL_MS = 250
+const POPUP_AUTH_MAX_RETRY_ATTEMPTS = 20
 const TOKEN_REFRESH_BUFFER_MS = 60_000
 const MIN_TOKEN_REFRESH_DELAY_MS = 1_000
 const TOKEN_REFRESH_RETRY_MS = 15_000
@@ -155,6 +165,12 @@ const InternalAuthProvider = ({
   const popupIntervalRef = useRef<ReturnType<typeof setInterval> | undefined>()
   /** Tracks the 5-minute popup auto-cleanup timer so it can be cleared on provider unmount. */
   const popupCleanupTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>()
+  /** Retries popup auth rehydration while the parent SDK instance catches up with shared storage. */
+  const popupAuthRetryTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>()
+  /** Marks that a popup completion signal was received and auth state is expected to rehydrate shortly. */
+  const popupAuthPendingRef = useRef<boolean>(false)
+  /** Counts popup auth rehydration retries so we can stop polling if the SDK never catches up. */
+  const popupAuthRetryCountRef = useRef<number>(0)
   /** Tracks the last access token so refresh callbacks only fire for real token transitions. */
   const lastAccessTokenRef = useRef<string | undefined>()
   /** Tracks the last access token expiry used in refresh callback payloads. */
@@ -236,6 +252,24 @@ const InternalAuthProvider = ({
     lastScheduledTokenExpRef.current = undefined
   }, [clearRefreshTimer])
 
+  const clearPopupAuthRetry = useCallback(() => {
+    clearTimeout(popupAuthRetryTimerRef.current)
+    popupAuthRetryTimerRef.current = undefined
+    popupAuthPendingRef.current = false
+    popupAuthRetryCountRef.current = 0
+  }, [])
+
+  const queuePopupAuthRefresh = useCallback((delayMs = POPUP_AUTH_EVENT_DELAY) => {
+    popupAuthPendingRef.current = true
+    popupAuthRetryCountRef.current = 0
+    clearTimeout(popupAuthRetryTimerRef.current)
+    popupAuthRetryTimerRef.current = setTimeout(() => {
+      if (!isUnmountedRef.current) {
+        void loadUserRef.current(true)
+      }
+    }, delayMs)
+  }, [])
+
   const scheduleTokenRefresh = useCallback(
     (exp?: number) => {
       clearRefreshTimer()
@@ -296,6 +330,7 @@ const InternalAuthProvider = ({
           const jwt = await getAccessToken(defaultResource)
 
           if (jwt) {
+            clearPopupAuthRetry()
             const nextUser = transformUser(claims)
             // Only set user as logged in if we actually have a valid access token
             const tokenExp = getJwtExpiration(jwt)
@@ -457,6 +492,23 @@ const InternalAuthProvider = ({
           }
         }
       } else {
+        if (forceRefresh && popupAuthPendingRef.current) {
+          if (popupAuthRetryCountRef.current < POPUP_AUTH_MAX_RETRY_ATTEMPTS) {
+            popupAuthRetryCountRef.current += 1
+            popupAuthRetryTimerRef.current = setTimeout(() => {
+              if (!isUnmountedRef.current) {
+                void loadUserRef.current(true)
+              }
+            }, POPUP_AUTH_RETRY_INTERVAL_MS)
+            // Keep the existing signed-in state intact while the parent SDK instance
+            // rehydrates from the tokens written by the popup flow.
+            setIsLoadingUser(false)
+            return
+          }
+
+          clearPopupAuthRetry()
+        }
+
         setUser(null)
         // Remove token cookie when not authenticated
         jwtCookieUtils.removeToken()
@@ -470,7 +522,19 @@ const InternalAuthProvider = ({
 
       setIsLoadingUser(false)
     },
-    [clearTrackedAccessToken, defaultResource, emitAuthError, emitTokenRefresh, getAccessToken, getIdTokenClaims, isAuthenticated, isLoading, performGlobalSignOut, resetRefreshSchedule, scheduleTokenRefresh],
+    [
+      clearTrackedAccessToken,
+      defaultResource,
+      emitAuthError,
+      emitTokenRefresh,
+      getAccessToken,
+      getIdTokenClaims,
+      isAuthenticated,
+      isLoading,
+      performGlobalSignOut,
+      resetRefreshSchedule,
+      scheduleTokenRefresh,
+    ],
   )
 
   useEffect(() => {
@@ -489,6 +553,7 @@ const InternalAuthProvider = ({
       // the provider is unmounted while a popup sign-in is still in progress.
       clearInterval(popupIntervalRef.current)
       clearTimeout(popupCleanupTimerRef.current)
+      clearTimeout(popupAuthRetryTimerRef.current)
     }
   }, [resetRefreshSchedule])
 
@@ -522,7 +587,7 @@ const InternalAuthProvider = ({
         // the new tokens that the popup stored in shared localStorage before we try to
         // read claims. forceRefresh bypasses rate-limiting and the isLoading early-return.
         setTimeout(() => {
-          loadUserRef.current(true) // forceRefresh=true to bypass rate limiting
+          queuePopupAuthRefresh()
           window.dispatchEvent(new CustomEvent('auth-state-changed'))
         }, POPUP_AUTH_EVENT_DELAY)
       }
@@ -619,7 +684,7 @@ const InternalAuthProvider = ({
             // before we attempt to read claims with forceRefresh=true.
             setTimeout(() => {
               if (!isUnmountedRef.current) {
-                loadUserRef.current(true) // forceRefresh=true to bypass rate limiting and isLoading check
+                queuePopupAuthRefresh(0)
                 window.dispatchEvent(new CustomEvent('auth-state-changed'))
               }
             }, POPUP_AUTH_EVENT_DELAY)
@@ -650,7 +715,7 @@ const InternalAuthProvider = ({
             // shared localStorage before we read claims with forceRefresh=true.
             setTimeout(() => {
               if (!isUnmountedRef.current) {
-                loadUserRef.current(true) // forceRefresh=true to bypass rate limiting
+                queuePopupAuthRefresh(0)
                 window.dispatchEvent(new CustomEvent('auth-state-changed'))
               }
             }, POPUP_AUTH_EVENT_DELAY)
@@ -686,6 +751,7 @@ const InternalAuthProvider = ({
       jwtCookieUtils.removeToken()
       resetRefreshSchedule()
       clearTrackedAccessToken()
+      clearPopupAuthRetry()
       emitSignOut({
         reason: 'user',
         global,
@@ -712,7 +778,7 @@ const InternalAuthProvider = ({
       // Dispatch custom event to notify other windows/tabs
       window.dispatchEvent(new CustomEvent('auth-state-changed'))
     },
-    [clearTrackedAccessToken, emitSignOut, logtoSignOut, resetRefreshSchedule],
+    [clearPopupAuthRetry, clearTrackedAccessToken, emitSignOut, logtoSignOut, resetRefreshSchedule],
   )
 
   const value: AuthContextType = useMemo(

--- a/src/user-center.test.tsx
+++ b/src/user-center.test.tsx
@@ -223,7 +223,28 @@ describe('UserCenter Component', () => {
 
       expect(signOut).toHaveBeenCalledWith({
         callbackUrl: 'https://example.com/current-page',
-        global: true,
+        global: false,
+      })
+    })
+
+    it('should default to local sign-out for safer account-menu behavior', () => {
+      const signOut = vi.fn()
+      mockUseAuth.mockReturnValue({
+        ...defaultMockAuth,
+        user: mockUser,
+        isLoadingUser: false,
+        signOut,
+      })
+
+      render(<UserCenter />)
+
+      const buttons = screen.getAllByTestId('button')
+      const signOutButton = buttons.find(btn => btn.textContent?.includes('Sign out'))
+      signOutButton?.click()
+
+      expect(signOut).toHaveBeenCalledWith({
+        callbackUrl: 'https://example.com/current-page',
+        global: false,
       })
     })
 
@@ -266,7 +287,7 @@ describe('UserCenter Component', () => {
 
       expect(signOut).toHaveBeenCalledWith({
         callbackUrl: customUrl,
-        global: true,
+        global: false,
       })
     })
   })
@@ -487,7 +508,7 @@ describe('UserCenter Component', () => {
 
       expect(signOut).toHaveBeenCalledWith({
         callbackUrl: 'https://example.com/current-page',
-        global: true,
+        global: false,
       })
     })
   })

--- a/src/user-center.tsx
+++ b/src/user-center.tsx
@@ -32,7 +32,7 @@ import type { AdditionalPage } from './types.js'
  *
  * @component
  * @param {string} [className] - CSS classes for the container element
- * @param {boolean} [globalSignOut=true] - Whether to perform global sign-out (logs out of entire Logto ecosystem) or local only
+ * @param {boolean} [globalSignOut=false] - Whether to perform global sign-out (logs out of entire Logto ecosystem) or local only
  * @param {string} [signoutCallbackUrl] - URL to redirect to after sign-out (default: current page)
  * @param {AdditionalPage[]} [additionalPages] - Array of custom pages/links to show in dropdown
  * @param {string} [themeClassnames] - Tailwind classnames for theming (light/dark mode)
@@ -65,7 +65,7 @@ export interface UserCenterProps {
 
 export const UserCenter: React.FC<UserCenterProps> = ({
   className = '',
-  globalSignOut = true,
+  globalSignOut = false,
   signoutCallbackUrl,
   additionalPages = [],
   themeClassnames = 'light:bg-stone-800 light:border-stone-700 light:text-stone-200',

--- a/tasks-v2.md
+++ b/tasks-v2.md
@@ -19,9 +19,11 @@
 
 **Priority: 🔴 Critical**
 
-- [ ] **CR-1 — Fix popup sign-in completion not rehydrating auth state in the parent app** Popup auth can complete successfully while `useAuth()` still reports `user: null` until the page is manually refreshed.
+- [x] **CR-1 — Fix popup sign-in completion not rehydrating auth state in the parent app** Popup auth can complete successfully while `useAuth()` still reports `user: null` until the page is manually refreshed.
 
   > Confirmed as a library issue in `src/context.tsx`. The popup completion handlers call `loadUserRef.current(true)`, but that path still depends on `useLogto()` already having flipped `isAuthenticated` in the parent window. When the popup closes before the parent Logto instance finishes rehydrating from shared storage, `loadUser()` falls through the unauthenticated branch and leaves the app signed out until a full reload reconstructs the provider.
+  >
+  > Fixed in `src/context.tsx` by treating popup completion as a short-lived rehydration window instead of an immediate signed-out state. Popup success/close handlers now queue a retryable forced refresh, and the unauthenticated branch preserves local state while the parent Logto SDK catches up from shared storage. Added a focused regression test in `src/context.test.tsx` that reproduces the exact race: popup completion arrives first, `isAuthenticated` flips on a later render, and the provider now recovers without a manual page reload.
 
 - [ ] **CR-2 — Fix local sign-out so `signOut({ global: false })` cannot cascade into tenant-wide logout** Consumers need a trustworthy app-local sign-out path that never logs them out of the entire Logto tenant as a side effect.
   > Confirmed as a library issue in `src/context.tsx`. The local sign-out branch clears React state and cookies, but it does not establish a durable local-only signed-out state in the underlying Logto session. On subsequent auth re-sync, the provider can still see an SDK-authenticated session and enter error-driven global logout paths. The implementation needs a true local-session clearing strategy and regression tests proving `global: false` never invokes tenant-wide logout behavior.

--- a/tasks-v2.md
+++ b/tasks-v2.md
@@ -25,14 +25,18 @@
   >
   > Fixed in `src/context.tsx` by treating popup completion as a short-lived rehydration window instead of an immediate signed-out state. Popup success/close handlers now queue a retryable forced refresh, and the unauthenticated branch preserves local state while the parent Logto SDK catches up from shared storage. Added a focused regression test in `src/context.test.tsx` that reproduces the exact race: popup completion arrives first, `isAuthenticated` flips on a later render, and the provider now recovers without a manual page reload.
 
-- [ ] **CR-2 — Fix local sign-out so `signOut({ global: false })` cannot cascade into tenant-wide logout** Consumers need a trustworthy app-local sign-out path that never logs them out of the entire Logto tenant as a side effect.
+- [x] **CR-2 — Fix local sign-out so `signOut({ global: false })` cannot cascade into tenant-wide logout** Consumers need a trustworthy app-local sign-out path that never logs them out of the entire Logto tenant as a side effect.
   > Confirmed as a library issue in `src/context.tsx`. The local sign-out branch clears React state and cookies, but it does not establish a durable local-only signed-out state in the underlying Logto session. On subsequent auth re-sync, the provider can still see an SDK-authenticated session and enter error-driven global logout paths. The implementation needs a true local-session clearing strategy and regression tests proving `global: false` never invokes tenant-wide logout behavior.
+  >
+  > Fixed in `src/context.tsx` by adding a tab-scoped local sign-out override stored in `sessionStorage` (`simple_logto_local_signout`). When `signOut({ global: false })` runs, the provider now clears local user state/cookies, suppresses future auth rehydration from the still-live Logto SDK session, and avoids falling into global logout/error recovery paths on later focus/storage/custom refresh events. The override is cleared automatically when the SDK really becomes unauthenticated or when the consumer starts a new sign-in flow. Added regression coverage proving local sign-out does not call the SDK global logout and remains stable across subsequent auth refresh events.
 
 > User test: Local signout doesn't work at all, nor on userCenter or a dedicated sign-out function
 
-- [ ] **CR-3 — Make `UserCenter` sign-out defaults safe and explicit** A drop-in account menu should not globally log the user out of their whole identity-provider session unless they opt into that behavior.
+- [x] **CR-3 — Make `UserCenter` sign-out defaults safe and explicit** A drop-in account menu should not globally log the user out of their whole identity-provider session unless they opt into that behavior.
 
   > Confirmed as a library issue in `src/user-center.tsx`. `globalSignOut` currently defaults to `true`, so a consumer that renders `UserCenter` without extra props gets tenant-wide logout by default. That default is too risky for a shared UI primitive and should either change to local sign-out or become explicitly named/labeled so it cannot be mistaken for a normal app logout.
+  >
+  > Changed the `UserCenter` default to `globalSignOut = false` and updated its JSDoc/tests/docs to treat app-local sign-out as the safe default. Consumers can still opt into tenant-wide logout explicitly with `globalSignOut={true}`, but rendering the component with no extra props no longer ends the user's wider Logto session by surprise.
 
 ---
 


### PR DESCRIPTION
## Summary
- fix popup sign-in completion so the parent app rehydrates auth state without a manual reload
- keep `signOut({ global: false })` app-scoped by persisting a local sign-out override in the provider
- make `UserCenter` default to local sign-out unless `globalSignOut={true}` is set explicitly
- update task tracking, docs, and regression tests for the new sign-out behavior

## Testing
- `npx vitest run src/context.test.tsx src/user-center.test.tsx`
- `npx tsc --project tsconfig.build.json --noEmit`

## Notes
- branch also includes the existing `.gitignore` commit for `example_app/.env`