### PR TITLE
chore: update repository links after rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security issue
-    url: https://github.com/thezem/simple-logto/security/policy
+    url: https://github.com/ouim-me/logto-authkit/security/policy
     about: Please report security vulnerabilities through the security policy instead of public issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ---
 
-[Unreleased]: https://github.com/ouim-me/simple-logto/compare/v0.3.0...HEAD
-[0.1.8]: https://github.com/ouim-me/simple-logto/releases/tag/v0.1.8
-[0.2.1]: https://github.com/ouim-me/simple-logto/releases/tag/v0.2.1
-[0.3.0]: https://github.com/ouim-me/simple-logto/releases/tag/v0.3.0
+[Unreleased]: https://github.com/ouim-me/logto-authkit/compare/v0.3.0...HEAD
+[0.1.8]: https://github.com/ouim-me/logto-authkit/releases/tag/v0.1.8
+[0.2.1]: https://github.com/ouim-me/logto-authkit/releases/tag/v0.2.1
+[0.3.0]: https://github.com/ouim-me/logto-authkit/releases/tag/v0.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,8 @@ Thank you for your interest in contributing! This document covers everything you
 
 ```bash
 # 1. Fork and clone the repo
-git clone https://github.com/ouim-me/simple-logto.git
-cd simple-logto
+git clone https://github.com/ouim-me/logto-authkit.git
+cd logto-authkit
 
 # 2. Install dependencies
 npm install

--- a/README.md
+++ b/README.md
@@ -2,14 +2,6 @@
 
 `@ouim/logto-authkit` is a batteries-included auth toolkit for Logto-powered React apps.
 
-> Migration notice
-> This package replaces `@ouim/simple-logto`.
-> Import replacements:
-> `@ouim/simple-logto` -> `@ouim/logto-authkit`
-> `@ouim/simple-logto/backend` -> `@ouim/logto-authkit/server`
-> `@ouim/simple-logto/bundler-config` -> `@ouim/logto-authkit/bundler-config`
-> There will be no compatibility shim for `/backend`.
-
 It wraps `@logto/react` with the pieces most teams end up building anyway:
 
 - a higher-level React provider and hook

--- a/docs/CI_CD_AND_RELEASES.md
+++ b/docs/CI_CD_AND_RELEASES.md
@@ -182,7 +182,7 @@ Automatically publishes to npm when a GitHub release is published.
 ### Security
 - Security improvement
 
-[0.1.9]: https://github.com/ouim-me/simple-logto/compare/v0.1.8...v0.1.9
+[0.1.9]: https://github.com/ouim-me/logto-authkit/compare/v0.1.8...v0.1.9
 ```
 
 3. **Create a GitHub Release:**

--- a/docs/LINKED_LOCAL_PACKAGE_TROUBLESHOOTING.md
+++ b/docs/LINKED_LOCAL_PACKAGE_TROUBLESHOOTING.md
@@ -5,7 +5,7 @@ This guide covers integration issues that show up when consuming `@ouim/logto-au
 ```json
 {
   "dependencies": {
-    "@ouim/logto-authkit": "file:../simple-logto"
+    "@ouim/logto-authkit": "file:../logto-authkit"
   }
 }
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,7 +101,7 @@ Focused guide for local `file:` dependencies and symlinked development:
 - preserving inherited `viteConfig.resolve` settings
 - Next.js App Router client-boundary issues
 
-**Read this if:** You're developing `@ouim/logto-authkit` locally and consuming it from another app via `file:../simple-logto` or a symlink.
+**Read this if:** You're developing `@ouim/logto-authkit` locally and consuming it from another app via `file:../logto-authkit` or a symlink.
 
 ---
 
@@ -242,7 +242,7 @@ Guidance for Claude Code and AI agents contributing to this repository. Includes
 ## Important Links
 
 ### Public Resources
-- **GitHub:** https://github.com/ouim-me/simple-logto
+- **GitHub:** https://github.com/ouim-me/logto-authkit
 - **npm:** https://www.npmjs.com/package/@ouim/logto-authkit
 - **Logto:** https://logto.io
 - **@logto/react:** https://docs.logto.io/docs/sdk/react

--- a/example_app/Implement_auth.md
+++ b/example_app/Implement_auth.md
@@ -334,7 +334,7 @@ MONGODB_URI=mongodb+srv://...
 ## References
 
 - [Logto Documentation](https://docs.logto.io)
-- [@ouim/logto-authkit source](https://github.com/thezem/simple-logto)
+- [@ouim/logto-authkit source](https://github.com/ouim-me/logto-authkit)
 - [Logto Documentation](https://docs.logto.io)
-- [@ouim/logto-authkit GitHub](https://github.com/thezem/simple-logto)
+- [@ouim/logto-authkit GitHub](https://github.com/ouim-me/logto-authkit)
 - [OAuth 2.0 Specification](https://tools.ietf.org/html/rfc6749)

--- a/package.json
+++ b/package.json
@@ -106,6 +106,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ouim-me/simple-logto.git"
+    "url": "git+https://github.com/ouim-me/logto-authkit.git"
   }
 }


### PR DESCRIPTION
## Summary
- update repository metadata and doc links after the GitHub repo rename to `ouim-me/logto-authkit`
- update clone URLs and local `file:` examples that still pointed at the old repo/folder name
- keep the README migration banner removed now that the new package is live and the old one is deprecated

## Included
- `package.json` repository URL updated to `ouim-me/logto-authkit`
- changelog release/compare links updated to the new repo slug
- docs and contributor instructions updated to the new repo URL and folder name
- issue template security link updated to the new repo
- example doc links updated from the old `thezem/simple-logto` URLs
- local git remote updated to the renamed GitHub repository

## Validation
- `npm run lint`
- `npx tsc --project tsconfig.build.json --noEmit`
- `npx vitest run`
- `npm run build`
- `npm run test:size`
- `npm run test:package`
- `npm run test:smoke`

## Note
- npm does have the package README in registry metadata (`npm view @ouim/logto-authkit readme`). If the npm web page still looks empty, that appears to be a UI/rendering issue rather than a missing published README.
